### PR TITLE
Changing short circuit argument re-definition to `undefined` rather t…

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -133,7 +133,7 @@
         var git = this;
         if (!then && typeof files === "function") {
             then = files;
-            files = [];
+            files = undefined;
         }
 
         files = files ? ' "' + [].concat(files).join('" "') + '"' : '';
@@ -287,7 +287,7 @@
     Git.prototype.listRemote = function (args, then) {
         if (!then && typeof args === "function") {
             then = args;
-            args = [];
+            args = undefined;
         }
 
         if (typeof args === 'string') {


### PR DESCRIPTION
…han []

I ran into an issue where I was calling `simpleGit.commit(message, function)` and was getting an issue about `""` file not being available.

On closer inspection it seemed that here we were resetting `files = []` which was still tripping the ternary reassignment which we didn't really want.

Note: I also changed this for `listRemote` exhibiting the same behavior, but I don't need that function (so less tested).

Second note: there might be something buggy about committing git repositories a different cwd than pwd, but didn't get a chance to dig deeper.