### PR TITLE
Add support for git log --merges

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -527,6 +527,14 @@
         if (opt.file) {
             command.push("--follow", options.file);
         }
+ /**
+  *
+  * Allow for comparing merges
+  *
+  */
+        if (opt.merges) {
+            command.push("--merges", options.branch + '..');
+        }
 
         return this._run(command, function (err, data) {
             handler && handler(err, !err && this._parseListLog(data));


### PR DESCRIPTION
Resolves #40.

Requires the following set in your config object:

```
config.merges: true,
config.branch: 'desired_branch' // will compare currently checked out branch with this
```