### PR TITLE
Fix parse git status

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -624,6 +624,7 @@
                 case "M":
                     modified.push(line.join());
                     break;
+                case "A":
                 case "AM":
                     created.push(line.join());
                     break;

--- a/test/testCommands.js
+++ b/test/testCommands.js
@@ -71,7 +71,7 @@ exports.status = {
 
     'modified status': function (test) {
         git.status(function (err, status) {
-            test.equals(2, status.created.length,      'No new files');
+            test.equals(3, status.created.length,      'No new files');
             test.equals(0, status.deleted.length,      'No removed files');
             test.equals(2, status.modified.length,     'No modified files');
             test.equals(1, status.not_added.length,    'No un-tracked files');
@@ -82,6 +82,7 @@ exports.status = {
         closeWith(' M package.json\n\
         M src/git.js\n\
         AM src/index.js \n\
+        A src/newfile.js \n\
         AM test.js\n\
         ?? test/ \n\
         ');


### PR DESCRIPTION
I use `git version 2.5.0.windows.1`.
Accordingly [git documentation](https://git-scm.com/docs/git-status) status of the worktree can be empty (`Y` parametr) and when i make git.status i get wrong result.
