### PR TITLE
Concat stdOut buffers before then.call

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -730,7 +730,7 @@
                     then.call(this, stdErr, null);
                 }
                 else {
-                    then.call(this, null, stdOut.toString('utf-8'));
+                    then.call(this, null, Buffer.concat(stdOut).toString('utf-8'));
                 }
 
                 process.nextTick(this._schedule.bind(this));


### PR DESCRIPTION
I noticed that commands producing large stdout values return data with a ',' in the middle. It looks like you are performing a Buffer.concat() for stderr (line 726), but not stdout. This fix is working for me. I have not tested against most of the commands.