### PR TITLE
Fix wrong git.log.latest.

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -847,7 +847,7 @@
       });
 
       return {
-         latest: logList.length && logList[logList.length - 1],
+         latest: logList.length && logList[0],
          total: logList.length,
          all: logList
       };


### PR DESCRIPTION
```
user@ubuntu14043:~/Desktop/test$ git log
commit cf59ea355a8a78d9bade91d394e57616353326a4
Author: baz <foo@bar.xyz>
Date:   Mon Jan 4 18:30:04 2016 +0100

    three   <--- this is the latest commit

commit 8f88715c0129a4edec7262af28328109190cfc3a
Author: baz <foo@bar.xyz>
Date:   Mon Jan 4 18:29:52 2016 +0100

    two

commit e24826717fe9fc48e7375ab43102f9790e0cfb29
Author: baz <foo@bar.xyz>
Date:   Mon Jan 4 18:29:40 2016 +0100

    one

user@ubuntu14043:~/Desktop/test$ node
> require('simple-git')().log(function(e,r) { console.log(r.latest); })

(...)

{ hash: '\'e24826717fe9fc48e7375ab43102f9790e0cfb29',
  date: '2016-01-04 18:29:40 +0100',
  message: 'one',
  author_name: 'baz',
  author_email: 'foo@bar.xyz\'' } <--- It returns the oldest commit.
```

Tested on git 2.6.4 on Windows and 1.9.1 on Linux Ubuntu.
Unit tests don't cover the .latest field.