### PR TITLE
Add support for base branch status (ahead/behind by how many commits)

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -91,7 +91,7 @@
     * @param {Function} [then]
     */
    Git.prototype.status = function (then) {
-      return this._run(['status', '--porcelain'], function (err, data) {
+      return this._run(['status', '--porcelain', '--branch'], function (err, data) {
          then && then(err, !err && this._parseStatus(data));
       });
    };
@@ -784,7 +784,7 @@
    };
 
    Git.prototype._parseStatus = function (status) {
-      var line;
+      var line, baseLine;
       var lines = status.trim().split('\n');
 
       var not_added = [];
@@ -792,6 +792,7 @@
       var modified = [];
       var created = [];
       var conflicted = [];
+      var base = [];
 
       var whitespace = /\s+/;
 
@@ -815,6 +816,10 @@
             case "UU":
                conflicted.push(line.join());
                break;
+            case "##":
+               baseLine = line.join(" ").match(/^(.*)\[(\D*) (\d*)\]/);
+               if(baseLine){base.push({branch:baseLine[1], status:baseLine[2], amount:baseLine[3]});}
+               break;
          }
       }
 
@@ -823,7 +828,8 @@
          deleted: deleted,
          modified: modified,
          created: created,
-         conflicted: conflicted
+         conflicted: conflicted,
+         base: base
       };
    };
 


### PR DESCRIPTION
I had a need for this feature, so implemented a "base branch" check this way in my local fork of simple-git.   If you agree this feature is useful and think the implementation is OK, you'd be welcome to use this code.

I think simple-git is a great tool!  Thanks for building it.