### PR TITLE
add support multipleline message for commit

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -137,7 +137,7 @@
     * Commits changes in the current working directory - when specific file paths are supplied, only changes on those
     * files will be committed.
     *
-    * @param {string} message
+    * @param {string|string[]} message
     * @param {string|string[]} [files]
     * @param {Function} [then]
     */
@@ -147,8 +147,20 @@
          then = files;
          files = [];
       }
+      
+      if (!Array.isArray(message)) {
+        message = [message];
+      }
+      
+      message = message.map(function(message) {
+        return ['-m', message];
+      })
+      .reduce(function(allMessage, message) {
+        allMessage = allMessage.concat(message);
+        return allMessage;
+      }, []);
 
-      return this._run(['commit', '-m', message].concat([].concat(files || [])), function (err, data) {
+      return this._run(['commit'].concat(message).concat([].concat(files || [])), function (err, data) {
          then && then(err, !err && require('./CommitSummary').parse(data));
       });
    };

--- a/test/testCommands.js
+++ b/test/testCommands.js
@@ -76,6 +76,26 @@ exports.commit = {
         create mode 100644 src/index.js');
     },
 
+    'commit with single file specified and multipleline commit': function (test) {
+        git.commit(['some', 'message'], 'fileName.ext', function (err, commit) {
+            test.equals('unitTests', commit.branch, 'Should be on unitTests branch');
+            test.equals('44de1ee', commit.commit, 'Should pick up commit hash');
+            test.equals(3, commit.summary.changes, 'Should pick up changes count');
+            test.equals(12, commit.summary.deletions, 'Should pick up deletions count');
+            test.equals(29, commit.summary.insertions, 'Should pick up insertions count');
+
+            test.same(
+               ["commit", "-m", "some", "-m" ,"message", "fileName.ext"],
+               theCommandRun());
+
+            test.done();
+        });
+
+        closeWith('[unitTests 44de1ee] Add nodeunit test runner\n\
+        3 files changed, 29 insertions(+), 12 deletions(-)\n\
+        create mode 100644 src/index.js');
+    },
+
     'commit with multiple files specified': function (test) {
         git.commit('some message', ['fileName.ext', 'anotherFile.ext'], function (err, commit) {
 
@@ -87,6 +107,27 @@ exports.commit = {
 
             test.same(
                ["commit", "-m", "some message", "fileName.ext", "anotherFile.ext"],
+               theCommandRun());
+
+            test.done();
+        });
+
+        closeWith('[branchNameInHere CommitHash] Add nodeunit test runner\n\
+        3 files changed, 29 insertions(+), 12 deletions(-)\n\
+        create mode 100644 src/index.js');
+    },
+    
+    'commit with multiple files specified and multipleline commit': function (test) {
+        git.commit(['some', 'message'], ['fileName.ext', 'anotherFile.ext'], function (err, commit) {
+
+            test.equals('branchNameInHere', commit.branch, 'Should pick up branch name');
+            test.equals('CommitHash', commit.commit, 'Should pick up commit hash');
+            test.equals(3, commit.summary.changes, 'Should pick up changes count');
+            test.equals(12, commit.summary.deletions, 'Should pick up deletions count');
+            test.equals(29, commit.summary.insertions, 'Should pick up insertions count');
+
+            test.same(
+               ["commit", "-m", "some", "-m" ,"message", "fileName.ext", "anotherFile.ext"],
                theCommandRun());
 
             test.done();
@@ -108,6 +149,27 @@ exports.commit = {
 
             test.same(
                ["commit", "-m", "some message"],
+               theCommandRun());
+
+            test.done();
+        });
+
+        closeWith('[branchNameInHere CommitHash] Add nodeunit test runner\n\
+        3 files changed, 10 insertions(+), 12 deletions(-)\n\
+        create mode 100644 src/index.js');
+    },
+    
+    'commit with no files specified and multipleline commit': function (test) {
+        git.commit(['some', 'message'], function (err, commit) {
+
+            test.equals('branchNameInHere', commit.branch, 'Should pick up branch name');
+            test.equals('CommitHash', commit.commit, 'Should pick up commit hash');
+            test.equals(3, commit.summary.changes, 'Should pick up changes count');
+            test.equals(12, commit.summary.deletions, 'Should pick up deletions count');
+            test.equals(10, commit.summary.insertions, 'Should pick up insertions count');
+
+            test.same(
+               ["commit", "-m", "some", "-m" ,"message"],
                theCommandRun());
 
             test.done();


### PR DESCRIPTION
git CLI allows us to commit message to have multiple lines with multiple flags -m  
example
```
git commit -m "some" -m "message"
```