### PR TITLE
Added support for add config keys.

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -340,6 +340,19 @@
    };
 
    /**
+    * Add config to local git instance
+    *
+    * @param {string} key configuration key (e.g user.name)
+    * @param {string} value for the given key (e.g your name)
+    * @param {Function} [then]
+    */
+   Git.prototype.addConfig = function (key, value, then) {
+      return this._run(['config', '--local', key, value], function (err, data) {
+         then && then(err, !err && data);
+      });
+   };
+
+   /**
     * Add a submodule
     *
     * @param {string} repo

--- a/test/testCommands.js
+++ b/test/testCommands.js
@@ -483,6 +483,25 @@ exports.remotes = {
     }
 };
 
+exports.config = {
+    setUp: function (done) {
+        Instance();
+        done();
+    },
+
+    'add': function (test) {
+        git.addConfig('user.name', 'test', function (err, result) {
+            test.equals(null, err, 'not an error');
+            test.same(
+               ['config', '--local', 'user.name', 'test'],
+               theCommandRun());
+            test.done();
+        });
+
+        closeWith('');
+    }
+};
+
 exports.reset = {
     setUp: function (done) {
         Instance();


### PR DESCRIPTION
I'm using this library with Heroku deployments and I don't have access to the git configuration. By default they don't have any user.name and user.email configured.

This PR aims to add support for addConfig function that will use the local instance to populate config options.

Usage:

```
_commitAndPushPost (resolve, reject) {
    return simpleGit(root)
     .outputHandler(function (command, stdout, stderr) {
       stdout.pipe(process.stdout);
       stderr.pipe(process.stderr);
     })
     .addConfig('user.name', USER_NAME)
     .addConfig('user.email', USER_EMAIL)
     ...
  }
```