### PR TITLE
Allow dots in branch name

### DIFF
--- a/src/StatusSummary.js
+++ b/src/StatusSummary.js
@@ -53,7 +53,7 @@ StatusSummary.parsers = {
    '##': function (line, status) {
       var aheadReg = /ahead (\d+)/;
       var behindReg = /behind (\d+)/;
-      var currentReg = /^([^\s\.]*)\.*/;
+      var currentReg = /^([^\s]*)\.*/;
       var trackingReg = /\.{3}(\S*)/;
       var regexResult;
 


### PR DESCRIPTION
The previous regex would not work for branches with dots, like `release/1.0.0`