### PR TITLE
Allowing .diffSummary to take options that are forwarded to .diff

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -721,7 +721,7 @@
 
    Git.prototype.diffSummary = function (options, then) {
       if (typeof options === 'string') {
-        options = options.join(' ');
+        options = options.split(' ');
         this._getLog('warn',
            'Git#diff: supplying options as a single string is now deprecated, switch to an array of strings');
       }

--- a/src/git.js
+++ b/src/git.js
@@ -719,8 +719,13 @@
       });
    };
 
-   Git.prototype.diffSummary = function (then) {
-      return this.diff(['--stat'], function (err, data) {
+   Git.prototype.diffSummary = function (options, then) {
+      if (typeof options === 'string') {
+        options = options.join(' ');
+        this._getLog('warn',
+           'Git#diff: supplying options as a single string is now deprecated, switch to an array of strings');
+      }
+      return this.diff(['--stat'].concat(options), function (err, data) {
          then && then(err, !err && require('./DiffSummary').parse(data));
       });
    };


### PR DESCRIPTION
Adding functionality to send options into `.diffSummary` to use with `.diff`.
This allows for example to diff commit ids without them being the current HEAD.