### PR TITLE
Added raw files status in index / working dir in git.status

### DIFF
--- a/src/StatusSummary.js
+++ b/src/StatusSummary.js
@@ -122,13 +122,13 @@ StatusSummary.parse = function (text) {
             handler(line[2], status);
          }
          if (line[1] != '##') {
-            let file_status = {
+            var file_status = {
                path: line[2],
                index: line[1][0],
                working_dir: line[1][1]
             }
             if (line[1].trim() == 'R') {
-               let detail = /^(.+) \-> (.+)$/.exec(line[2]) || [null, line[2], line[2]];
+               var detail = /^(.+) \-> (.+)$/.exec(line[2]) || [null, line[2], line[2]];
                file_status.path = detail[2];
                file_status.from = detail[1];
             }

--- a/test/test-status.js
+++ b/test/test-status.js
@@ -123,5 +123,20 @@ exports.status = {
         ?? test/ \n\
         UU test.js\n\
         ');
+   },
+
+   'index/wd status': function (test) {
+      git.status(function (err, status) {
+         test.same(status.files, [
+           {path: 'src/git_wd.js', index: ' ', working_dir: 'M'},
+           {path: 'src/git_ind_wd.js', index: 'M', working_dir: 'M'},
+           {path: 'src/git_ind.js', index: 'M', working_dir: ' '}
+         ])
+         test.done();
+      });
+
+      setup.closeWith(' M src/git_wd.js\n\
+MM src/git_ind_wd.js\n\
+M  src/git_ind.js\n');
    }
 };


### PR DESCRIPTION
This adds the raw array of path / status letters to the result of git.status.

This allows to parse the types MM, DM, etc. that were currently skipped, without adding more arrays, and to differenciate if the modifications are on the index (like "M*(space)(space)*file.js") or working directory (like "*(space)*M*(space)*file.js")