### PR TITLE
Custom format option for git.log

### DIFF
--- a/src/ListLogSummary.js
+++ b/src/ListLogSummary.js
@@ -30,18 +30,17 @@ ListLogSummary.prototype.latest = null;
  */
 ListLogSummary.prototype.total = 0;
 
-function ListLogLine (line) {
-   this.hash = line[0];
-   this.date = line[1];
-   this.message = line[2];
-   this.author_name = line[3];
-   this.author_email = line[4];
+function ListLogLine (line, fields) {
+   for (var k = 0; k < fields.length; k++) {
+      this[fields[k]] = line[k];
+   }
 }
 
-ListLogSummary.parse = function (text, splitter) {
+ListLogSummary.parse = function (text, splitter, fields) {
+   fields = fields || ['hash', 'date', 'message', 'author_name', 'author_email'];
    return new ListLogSummary(
       text.split('\n').filter(Boolean).map(function (item) {
-         return new ListLogLine(item.split(splitter));
+         return new ListLogLine(item.split(splitter), fields);
       })
    );
 };

--- a/src/git.js
+++ b/src/git.js
@@ -1008,7 +1008,16 @@
       var opt = (handler === then ? options : null) || {};
 
       var splitter = opt.splitter || ';';
-      var command = ["log", "--pretty=format:%H %ai %s%d %aN %ae".replace(/\s+/g, splitter)];
+      var format = opt.format || {
+         hash: '%H',
+         date: '%ai',
+         message: '%s%d',
+         author_name: '%aN',
+         author_email: '%ae'
+      };
+      var fields = Object.keys(format);
+      var formatstr = fields.map(function(k) { return format[k]; }).join(splitter);
+      var command = ["log", "--pretty=format:" + formatstr];
 
 
       if (Array.isArray(opt)) {
@@ -1043,7 +1052,7 @@
       Git._appendOptions(command, opt);
 
       return this._run(command, function (err, data) {
-         handler && handler(err, !err && require('./ListLogSummary').parse(data, splitter));
+         handler && handler(err, !err && require('./ListLogSummary').parse(data, splitter, fields));
       });
    };
 

--- a/src/git.js
+++ b/src/git.js
@@ -1045,7 +1045,7 @@
          command.push("--max-count=" + (opt.n || opt['max-count']));
       }
 
-      'splitter n max-count file from to --pretty'.split(' ').forEach(function (key) {
+      'splitter n max-count file from to --pretty format'.split(' ').forEach(function (key) {
          delete opt[key];
       });
 

--- a/test/test-log.js
+++ b/test/test-log.js
@@ -134,6 +134,30 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
       });
 
       setup.closeWith('');
+   },
+
+   'with custom format option': function (test) {
+      git.log({
+         format: {
+            'myhash': '%H',
+            'message': '%s',
+            'refs': '%D'
+         }
+      }, function (err, result) {
+         test.equals(null, err, 'not an error');
+         test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.myhash, 'custom field name');
+         test.same('Fix log.latest.', result.latest.message);
+         test.same('HEAD, stmbgr-master', result.latest.refs);
+         test.done();
+      });
+
+      setup.closeWith([
+         'ca931e641eb2929cf86093893e9a467e90bf4c9b;Fix log.latest.;HEAD, stmbgr-master',
+         '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805;Release 1.20.0;origin/master, origin/HEAD, master',
+         'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;Support for any parameters to `git log` by supplying `options` as an array;tag: 1.20.0',
+         '207601debebc170830f2921acf2b6b27034c3b1f;Release 1.19.0;'
+      ].join('\n'))
+
    }
 };
 

--- a/test/test-log.js
+++ b/test/test-log.js
@@ -145,6 +145,10 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          }
       }, function (err, result) {
          test.equals(null, err, 'not an error');
+         test.same([
+            "log",
+            "--pretty=format:%H;%s;%D",
+         ], setup.theCommandRun());
          test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.myhash, 'custom field name');
          test.same('Fix log.latest.', result.latest.message);
          test.same('HEAD, stmbgr-master', result.latest.refs);


### PR DESCRIPTION
This adds an option "format" to git.log, which is an object that maps a field to a placeholder. This allows to use the other informations than only the hash/date/message/author's name and email

e.g.
```javascript
git.log({
   format: {
      'hash': '%H',
      'message': '%s',
      'refs': '%D',
      'parents': '%P'
      }
}, ...
```