### PR TITLE
Add travis + badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+ - "7"
+install:
+ - "npm install"
+script:
+ - "npm test"
+branches:
+  only:
+    - master

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Simple Git
-[![NPM version](http://img.shields.io/npm/v/simple-git.svg)](https://www.npmjs.com/package/simple-git)
+[![NPM version](http://img.shields.io/npm/v/simple-git.svg)](https://www.npmjs.com/package/simple-git) [![Build Status](https://travis-ci.org/steveukx/git-js.svg?branch=master)](https://travis-ci.org/steveukx/git-js)
 
 A light weight interface for running git commands in any [node.js](http://nodejs.org) application.
 


### PR DESCRIPTION
This adds build status (npm test) badge on your readme. If you did not do it, you only have to github connect on [travis](https://travis-ci.org/) and enable it on [github](https://github.com/dwyl/learn-travis).