### PR TITLE
Promise wrapped interface does not support non-chaining in the event of errors.

### DIFF
--- a/test/integration/test-broken-chains.js
+++ b/test/integration/test-broken-chains.js
@@ -1,8 +1,8 @@
 'use strict';
 
 /*
-   The broken chains test assures the behaviour of both standard and Promise wrapped versions
-   of the simple-git library.
+   The broken chains test assures the behaviour of the original (chain based) interface to
+   the simple-git library.
 
    Failures (exit code other than zero and some content in the stderr output) cause the current
    queue to be truncated and no additional steps to be taken.
@@ -58,32 +58,7 @@ const multiStepTest = (context, assert) => {
    return result.promise;
 };
 
-const testP = (context, assert) => {
-   let git = context.gitP(context.root).silent(true);
-   let result = context.deferred();
-   let successes = [];
-
-   git.status()
-      .then(res => {
-         successes.push(res);
-      })
-      .then(() => git.status())
-      .then((res) => {
-         successes.push(res);
-      })
-      .then(() => {
-         result.resolve(new Error('Should not have been a success, first stage must throw when not a valid repo'));
-      })
-      .catch(err => {
-         assert.equal(successes.length, 0, 'Should not have processed any step as a success');
-         result.resolve();
-      });
-
-   return result.promise;
-};
-
 module.exports = {
-   'standard': new Test(setUp, test),
-   'multi-step standard': new Test(setUp, multiStepTest),
-   'promise': new Test(setUp, testP)
+   'single-chain with errors': new Test(setUp, test),
+   'multi-chain with errors in each': new Test(setUp, multiStepTest)
 };

--- a/test/integration/test-broken-promise-chains.js
+++ b/test/integration/test-broken-promise-chains.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/*
+   The broken promise chains test assures the behaviour of Promise wrapped versions of the simple-git library.
+
+   Failures (exit code other than zero and some content in the stderr output) cause the current
+   queue to be truncated and no additional steps to be taken.
+
+   In the case of a promise chain, the `catch` handler should be called on the first error
+   and no other steps in the chain be executed.
+ */
+const Test = require('./include/runner');
+
+const setUp = (context) => {
+   return Promise.resolve();
+};
+
+const testP = (context, assert) => {
+   let git = context.gitP(context.root).silent(true);
+   let result = context.deferred();
+   let successes = [];
+
+   git.status()
+      .then(res => {
+         successes.push(res);
+      })
+      .then(() => git.status())
+      .then((res) => {
+         successes.push(res);
+      })
+      .then(() => {
+         result.resolve(new Error('Should not have been a success, first stage must throw when not a valid repo'));
+      })
+      .catch(err => {
+         assert.equal(successes.length, 0, 'Should not have processed any step as a success');
+         result.resolve();
+      });
+
+   return result.promise;
+};
+
+const testPromiseNotChained = (context, assert) => {
+   let git = context.gitP(context.root).silent(true);
+   let result = context.deferred();
+   let failures = [];
+
+   const status = (step) => {
+      return git.status()
+         .then(() => {
+            result.resolve(new Error('Should not have been a success: ' + step));
+         }, () => {
+            failures.push(step)
+         });
+   };
+
+   Promise.all([
+         status('a'),
+         status('b'),
+         status('c')
+      ])
+      .then(function () {
+         assert.deepEqual(['a', 'b', 'c'], failures.sort(), 'All steps should be an error');
+         result.resolve();
+      });
+
+   setTimeout(function () {
+      result.resolve(new Error('Test timed out - currently seen ' + failures));
+   }, 1000);
+
+   return result.promise;
+};
+
+module.exports = {
+   'written as a chain': new Test(setUp, testP),
+   'written without chains': new Test(setUp, testPromiseNotChained)
+};

--- a/test/integration/test-broken-promise-chains.js
+++ b/test/integration/test-broken-promise-chains.js
@@ -72,5 +72,7 @@ const testPromiseNotChained = (context, assert) => {
 
 module.exports = {
    'written as a chain': new Test(setUp, testP),
-   'written without chains': new Test(setUp, testPromiseNotChained)
+   // FIXME: #136
+   // 'written without chains': new Test(setUp, testPromiseNotChained)
+
 };


### PR DESCRIPTION
Related to #136, when the promise wrapped version of simple-git encounters an error in one of the items in the chain, it doesn't terminate all other steps in the chain that have been added after it.

Use case:

```
const gitP = require('simple-git/promise')(path);

Promise.all([
   gitP.status().then(handleStatus),
   gitP.fetch().then(handleFetch)
])
.then(done);
```

`status` and `fetch` will be called one after the other in the standard chained version of `simple-git`, but as the standard API only calls the first callback in the case of an error, the `fetch` Promise will never resolve.
