### PR TITLE
Fix: handle multiline commit

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1055,9 +1055,10 @@
          author_name: '%aN',
          author_email: '%ae'
       };
+
       var fields = Object.keys(format);
       var formatstr = fields.map(function(k) { return format[k]; }).join(splitter);
-      var command = ["log", "--pretty=format:" + formatstr];
+      var command = ["log", "--pretty=format:" + formatstr + '------------------------ >8 ------------------------'];
 
 
       if (Array.isArray(opt)) {

--- a/src/responses/ListLogSummary.js
+++ b/src/responses/ListLogSummary.js
@@ -39,7 +39,7 @@ function ListLogLine (line, fields) {
 ListLogSummary.parse = function (text, splitter, fields) {
    fields = fields || ['hash', 'date', 'message', 'author_name', 'author_email'];
    return new ListLogSummary(
-      text.split('\n').filter(Boolean).map(function (item) {
+      text.split('------------------------ >8 ------------------------\n').filter(Boolean).map(function (item) {
          return new ListLogLine(item.split(splitter), fields);
       })
    );

--- a/src/responses/ListLogSummary.js
+++ b/src/responses/ListLogSummary.js
@@ -39,7 +39,12 @@ function ListLogLine (line, fields) {
 ListLogSummary.parse = function (text, splitter, fields) {
    fields = fields || ['hash', 'date', 'message', 'author_name', 'author_email'];
    return new ListLogSummary(
-      text.split('------------------------ >8 ------------------------\n').filter(Boolean).map(function (item) {
+      text.split('------------------------ >8 ------------------------\n')
+        .map(function (item){
+          return item.replace('------------------------ >8 ------------------------', '')
+        })
+        .filter(Boolean)
+        .map(function (item) {
          return new ListLogLine(item.split(splitter), fields);
       })
    );

--- a/test/unit/test-commands.js
+++ b/test/unit/test-commands.js
@@ -2,6 +2,8 @@
 
 const setup = require('./include/setup');
 const sinon = require('sinon');
+const commitSplitter = '------------------------ >8 ------------------------';
+
 var sandbox = null;
 var git = null;
 
@@ -975,7 +977,7 @@ exports.stashList = {
         });
 
         closeWith('\
-8701efc4f6663bcdc6908001926c077c4a983f71;2016-07-08 14:58:53 -0400;WIP on master: 1234567 commit comment 1 (refs/stash);Some Author;some@author.com\n\
+8701efc4f6663bcdc6908001926c077c4a983f71;2016-07-08 14:58:53 -0400;WIP on master: 1234567 commit comment 1 (refs/stash);Some Author;some@author.com' + commitSplitter + '\n\
 a8f9fd225fda404fab96c6a39bd2cc4fa423286f;2016-06-06 18:18:43 -0400;WIP on master: 7654321 commit comment 2;Some Author;some@author.com');
     },
 };

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -182,6 +182,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.myhash, 'custom field name');
          test.same('Fix log.latest.\n\nDescribe the fix', result.latest.message);
          test.same('HEAD, stmbgr-master', result.latest.refs);
+         test.same('tag: 1.20.0', result.all.slice(-1)[0].refs);
          test.done();
       });
 
@@ -189,8 +190,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
       setup.closeWith([
          "ca931e641eb2929cf86093893e9a467e90bf4c9b;Fix log.latest.\n\nDescribe the fix;HEAD, stmbgr-master",
          '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805;Release 1.20.0;origin/master, origin/HEAD, master',
-         'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;Support for any parameters to `git log` by supplying `options` as an array;tag: 1.20.0',
-         '207601debebc170830f2921acf2b6b27034c3b1f;Release 1.19.0;'
+         'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;Support for any parameters to `git log` by supplying `options` as an array;tag: 1.20.0' + commitSplitter,
       ].join(`${commitSplitter}\n`))
 
    },
@@ -207,6 +207,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
             `--pretty=format:%b${commitSplitter}`
          ], setup.theCommandRun());
          test.same('Fix log.latest.\n\nDescribe the fix', result.latest.message);
+         test.same('Release 1.19.0', result.all.slice(-1)[0].message);
          test.done();
       });
 
@@ -215,7 +216,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          "Fix log.latest.\n\nDescribe the fix",
          'Release 1.20.0',
          'Support for any parameters to `git log` by supplying `options` as an array',
-         'Release 1.19.0'
+         'Release 1.19.0' + commitSplitter
       ].join(`${commitSplitter}\n`))
 
    }

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -2,6 +2,7 @@
 
 const setup = require('./include/setup');
 const sinon = require('sinon');
+const commitSplitter = '------------------------ >8 ------------------------';
 
 var git, sandbox;
 
@@ -39,13 +40,13 @@ exports.log = {
          '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805;2016-01-03 16:02:22 +0000;Release 1.20.0 (origin/master, origin/HEAD, master);Steve King;steve@mydev.co',
          'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;2016-01-03 16:02:04 +0000;Support for any parameters to `git log` by supplying `options` as an array (tag: 1.20.0);Steve King;ste',
          '207601debebc170830f2921acf2b6b27034c3b1f;2016-01-03 15:50:58 +0000;Release 1.19.0;Steve King;steve@mydev.co'
-      ].join('\n'))
+      ].join(`${commitSplitter}\n`))
    },
 
    'uses custom splitter': function (test) {
       git.log({splitter: "::"}, function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", "--pretty=format:%H::%ai::%s%d::%aN::%ae"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H::%ai::%s%d::%aN::%ae${commitSplitter}`], setup.theCommandRun());
          test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.hash, 'knows which is latest');
          test.same(4, result.total, 'picked out all items');
 
@@ -57,13 +58,13 @@ exports.log = {
          '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805::2016-01-03 16:02:22 +0000::Release 1.20.0 (origin/master, origin/HEAD, master)::Steve King::steve@mydev.co',
          'd4bdd0c823584519ddd70f8eceb8ff06c0d72324::2016-01-03 16:02:04 +0000::Support for any parameters to `git log` by supplying `options` as an array (tag: 1.20.0)::Steve King::ste',
          '207601debebc170830f2921acf2b6b27034c3b1f::2016-01-03 15:50:58 +0000::Release 1.19.0::Steve King::steve@mydev.co'
-      ].join('\n'))
+      ].join(`${commitSplitter}\n`))
    },
 
    'with explicit from and to': function (test) {
       git.log('from', 'to', function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", "--pretty=format:%H;%ai;%s%d;%aN;%ae", "from...to"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "from...to"], setup.theCommandRun());
          test.done();
       });
 
@@ -78,7 +79,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
    'with options array': function (test) {
       git.log(['--some=thing'], function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", "--pretty=format:%H;%ai;%s%d;%aN;%ae", "--some=thing"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--some=thing"], setup.theCommandRun());
          test.done();
       });
 
@@ -93,7 +94,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
    'with max count shorthand property': function (test) {
       git.log({n: 5}, function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", "--pretty=format:%H;%ai;%s%d;%aN;%ae", "--max-count=5"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--max-count=5"], setup.theCommandRun());
          test.done();
       });
 
@@ -108,7 +109,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
    'with max count longhand property': function (test) {
       git.log({n: 5}, function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", "--pretty=format:%H;%ai;%s%d;%aN;%ae", "--max-count=5"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--max-count=5"], setup.theCommandRun());
          test.done();
       });
 
@@ -125,7 +126,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          test.equals(null, err, 'not an error');
          test.same([
             "log",
-            "--pretty=format:%H;%ai;%s%d;%aN;%ae",
+            `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`,
             "--max-count=5",
             "--custom",
             "--custom-with-value=123"
@@ -147,7 +148,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          test.equals(null, err, 'not an error');
          test.same([
             "log",
-            "--pretty=format:%H;%s;%D"
+            `--pretty=format:%H;%s;%D${commitSplitter}`
          ], setup.theCommandRun());
          test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.myhash, 'custom field name');
          test.same('Fix log.latest.', result.latest.message);
@@ -155,13 +156,68 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          test.done();
       });
 
+
       setup.closeWith([
-         'ca931e641eb2929cf86093893e9a467e90bf4c9b;Fix log.latest.;HEAD, stmbgr-master',
+           'ca931e641eb2929cf86093893e9a467e90bf4c9b;Fix log.latest.;HEAD, stmbgr-master',
          '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805;Release 1.20.0;origin/master, origin/HEAD, master',
          'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;Support for any parameters to `git log` by supplying `options` as an array;tag: 1.20.0',
          '207601debebc170830f2921acf2b6b27034c3b1f;Release 1.19.0;'
-      ].join('\n'))
+      ].join(`${commitSplitter}\n`))
+
+   },
+
+   'with custom format option on multiline commit': function (test) {
+      git.log({
+         format: {
+           'myhash': '%H',
+           'message': '%b',
+           'refs': '%D'
+         }
+      }, function (err, result) {
+         test.equals(null, err, 'not an error');
+         test.same([
+            "log",
+            `--pretty=format:%H;%b;%D${commitSplitter}`
+         ], setup.theCommandRun());
+         test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.myhash, 'custom field name');
+         test.same('Fix log.latest.\n\nDescribe the fix', result.latest.message);
+         test.same('HEAD, stmbgr-master', result.latest.refs);
+         test.done();
+      });
+
+
+      setup.closeWith([
+         "ca931e641eb2929cf86093893e9a467e90bf4c9b;Fix log.latest.\n\nDescribe the fix;HEAD, stmbgr-master",
+         '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805;Release 1.20.0;origin/master, origin/HEAD, master',
+         'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;Support for any parameters to `git log` by supplying `options` as an array;tag: 1.20.0',
+         '207601debebc170830f2921acf2b6b27034c3b1f;Release 1.19.0;'
+      ].join(`${commitSplitter}\n`))
+
+   },
+
+   'with custom format %b option on multiline commit ': function (test) {
+      git.log({
+         format: {
+           'message': '%b',
+         }
+      }, function (err, result) {
+         test.equals(null, err, 'not an error');
+         test.same([
+            "log",
+            `--pretty=format:%b${commitSplitter}`
+         ], setup.theCommandRun());
+         test.same('Fix log.latest.\n\nDescribe the fix', result.latest.message);
+         test.done();
+      });
+
+
+      setup.closeWith([
+         "Fix log.latest.\n\nDescribe the fix",
+         'Release 1.20.0',
+         'Support for any parameters to `git log` by supplying `options` as an array',
+         'Release 1.19.0'
+      ].join(`${commitSplitter}\n`))
 
    }
-};
 
+};


### PR DESCRIPTION
The fix allow the use of %b within the --pretty=format: when the description is written on more than one line.

A string is used in complement of \n to split commits.

