### PR TITLE
Fix `git.raw` command

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -543,11 +543,11 @@
 
       var next = Git.trailingFunctionArgument(arguments);
 
-      if (command[0] !== 'git') {
-         command.unshift('git');
+      if (command[0] === 'git') {
+         command.shift('git');
       }
 
-      if (command.length < 2) {
+      if (!command.length) {
          return this.then(function () {
             next && next(new Error('Raw: must supply one or more command to execute'), null);
          });

--- a/test/unit/test-raw.js
+++ b/test/unit/test-raw.js
@@ -23,11 +23,22 @@ exports.raw = {
       done();
    },
 
+   'removes git from arguments': function (test) {
+      git.raw(['git', 'abc'], function (err, result) {
+         test.equal(err, null);
+         test.equal(result, 'passed through raw response');
+         test.deepEqual(setup.theCommandRun(), ['abc']);
+
+         test.done();
+      });
+      setup.closeWith('passed through raw response');
+   },
+
    'accepts an array of arguments': function (test) {
       git.raw(['abc', 'def'], function (err, result) {
          test.equal(err, null);
          test.equal(result, 'passed through raw response');
-         test.deepEqual(setup.theCommandRun(), ['git', 'abc', 'def']);
+         test.deepEqual(setup.theCommandRun(), ['abc', 'def']);
 
          test.done();
       });
@@ -38,7 +49,7 @@ exports.raw = {
       git.raw({'abc': 'def'}, function (err, result) {
          test.equal(err, null);
          test.equal(result, 'another raw response');
-         test.deepEqual(setup.theCommandRun(), ['git', 'abc=def']);
+         test.deepEqual(setup.theCommandRun(), ['abc=def']);
 
          test.done();
       });
@@ -60,7 +71,7 @@ exports.raw = {
       git.raw(['something']);
       test.doesNotThrow(function () {
          setup.closeWith('');
-         test.deepEqual(['git', 'something'], setup.theCommandRun());
+         test.deepEqual(['something'], setup.theCommandRun());
       });
       test.done();
    },


### PR DESCRIPTION
I tried to run the `git.raw` command, but the following error occurred:
```
git: 'git' is not a git command. See 'git --help'.
```
It is obvious, that Git tries to execute something like `git git [args...]`.

### Issue: ###
According to the documentation:
> (module) Relies on git already having been installed on the system, and that it can be called using the command git.

So, there is no reason to prepend the arguments list with `'git'`, right?

`git.raw` as all the other methods use `_run(command, then, opt)` function to execute commands. None of them adds `'git'` as the first argument, except for `git.raw`.

### Fix: ###
We should do the opposite and remove the `'git'` if it's is present.
Or, we can remove the check for `'git'` as the first argument completely, as it was [before](https://github.com/steveukx/git-js/commit/204f2fd1d77ee5f8475c47f44acc8014d7534b00#diff-967b50994c30d119b23ad740ba204028R546).

**Changed:**
* `git.raw` will remove `'git'` from the arguments, if it's present as the first element.

**Added:**
* `git.raw` test case for the new behavior.