### PR TITLE
Validate path when changing the working directory

### DIFF
--- a/test/integration/test-change-directory.js
+++ b/test/integration/test-change-directory.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/*
+
+ */
+const Test = require('./include/runner');
+const FS = require('fs');
+const sinon = require('sinon');
+
+const setUp = (context) => {
+   return Promise.resolve();
+};
+
+const test = (context, assert) => {
+
+   let validWorkingDirectory = `${context.root}/good`;
+   let invalidWorkingDirectory = `${context.root}/bad`;
+
+   FS.mkdirSync(validWorkingDirectory);
+
+   const spies = [
+      sinon.spy(),
+      sinon.spy(),
+      sinon.spy()
+   ];
+
+   context.git(context.root)
+      .silent(true)
+      .cwd(validWorkingDirectory, spies[0])
+      .cwd(invalidWorkingDirectory, spies[1])
+      .cwd(validWorkingDirectory, spies[2]);
+
+   return new Promise((pass) => {
+      setTimeout(function () {
+         assert.ok(spies[0].calledWith(null, validWorkingDirectory), 'Change to valid directory is ok');
+         assert.ok(spies[1].calledWith(sinon.match.instanceOf(Error)), 'Change to invalid directory is error');
+         assert.ok(spies[2].notCalled, 'After an error no more steps are processed');
+
+         pass();
+      }, 250);
+   });
+};
+
+
+module.exports = {
+   'switches into new directory': new Test(setUp, test)
+};

--- a/test/unit/test-commands.js
+++ b/test/unit/test-commands.js
@@ -80,39 +80,6 @@ exports.clone = {
     }
 };
 
-exports.cwd = {
-    setUp: function (done) {
-        git = Instance('/base/dir');
-        done();
-    },
-
-    'changes working directory': function (test) {
-        var callbacks = 0;
-        git
-           .init(function () {
-               callbacks++;
-               var mockChildProcess = getCurrentMockChildProcess();
-               test.equals('/base/dir', mockChildProcess.spawn.args[0][2].cwd)
-            })
-           .cwd('/something/else')
-           .init(function () {
-               callbacks++;
-               var mockChildProcess = getCurrentMockChildProcess();
-               test.equals('/something/else', mockChildProcess.spawn.args[2][2].cwd);
-
-               test.done();
-           });
-
-        closeWith('');
-        setTimeout(function () {
-            closeWith('')
-        }, 25);
-        setTimeout(function () {
-            closeWith('')
-        }, 50);
-    }
-};
-
 exports.commit = {
     setUp: function (done) {
         git = Instance();

--- a/test/unit/test-cwd.js
+++ b/test/unit/test-cwd.js
@@ -34,7 +34,6 @@ exports.cwd = {
       setup.closeWith('');
    },
 
-
    'to an invalid directory': function (test) {
       git.cwd('./invalid_path', function (err, result) {
          test.ok(err instanceof Error, 'Should be an error');

--- a/test/unit/test-cwd.js
+++ b/test/unit/test-cwd.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const setup = require('./include/setup');
+const sinon = require('sinon');
+
+var git, sandbox;
+
+exports.setUp = function (done) {
+   setup.restore();
+   sandbox = sinon.sandbox.create();
+   done();
+};
+
+exports.tearDown = function (done) {
+   setup.restore();
+   sandbox.restore();
+   done();
+};
+
+exports.cwd = {
+   setUp: function (done) {
+      git = setup.Instance();
+      done();
+   },
+
+   'to a known directory': function (test) {
+      git.cwd('./', function (err, result) {
+         test.equals(null, err, 'not an error');
+         test.equals('./', result);
+
+         test.done();
+      });
+
+      setup.closeWith('');
+   },
+
+
+   'to an invalid directory': function (test) {
+      git.cwd('./invalid_path', function (err, result) {
+         test.ok(err instanceof Error, 'Should be an error');
+         test.ok(/invalid_path/.test(err), 'Error should include deatil of the invalid path');
+
+         test.done();
+      });
+
+      setup.closeWith('');
+   }
+};


### PR DESCRIPTION
Adds validation to the `cwd` step to ensure the directory that will become the new working directory is a valid path before continuing.

Helps to diagnose issues noted in #159