### PR TITLE
fix(status): list untracked files

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -118,7 +118,7 @@
     */
    Git.prototype.status = function (then) {
       return this._run(
-         ['status', '--porcelain', '-b'],
+         ['status', '--porcelain', '-b', '-u'],
          Git._responseHandler(then, 'StatusSummary')
       );
    };


### PR DESCRIPTION
Currently, when you have a folder and all files are untracked, it will list the folder instead of the files.
This changes it to list the files instead.

```txt
package.json (tracked)
/typings/simple-git/promise/index.d.ts (untracked)
/typings/simple-git/response.d.ts (untracked)

/typings/simple-git/ (all files are all untracked)
````

Current output `git status --porcelain -b`
```txt
M package.json
?? typings/simple-git/
```

Proposed output `git status --porcelain -b -u`
```txt
M package.json
?? typings/simple-git/promise/index.d.ts
?? typings/simple-git/response.d.ts
```