### PR TITLE
Support all git-branch delete options`

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -511,6 +511,7 @@
     * @param {Function} [then]
     */
    Git.prototype.branch = function (options, then) {
+      var isDelete, responseHandler;
       var next = Git.trailingFunctionArgument(arguments);
       var command = ['branch'];
       if (Array.isArray(options)) {
@@ -522,11 +523,11 @@
          command.push('-a', '-v');
       }
 
-      var isDelete = ['-d', '-D', '--delete'].reduce(function (isDelete, flag) {
+      isDelete = ['-d', '-D', '--delete'].reduce(function (isDelete, flag) {
          return isDelete || command.indexOf(flag) > 0;
       }, false);
 
-      var responseHandler = isDelete 
+      responseHandler = isDelete 
          ? Git._responseHandler(next, 'BranchDeleteSummary', false)
          : Git._responseHandler(next, 'BranchSummary');
 

--- a/src/git.js
+++ b/src/git.js
@@ -522,9 +522,15 @@
          command.push('-a', '-v');
       }
 
-      return this._run(command, command.indexOf('-d') > 0
+      var isDelete = ['-d', '-D', '--delete'].reduce(function (isDelete, flag) {
+         return isDelete || command.indexOf(flag) > 0;
+      }, false);
+
+      var responseHandler = isDelete 
          ? Git._responseHandler(next, 'BranchDeleteSummary', false)
-         : Git._responseHandler(next, 'BranchSummary'));
+         : Git._responseHandler(next, 'BranchSummary');
+
+      return this._run(command, responseHandler);
    };
 
    /**

--- a/test/unit/test-branch.js
+++ b/test/unit/test-branch.js
@@ -3,6 +3,7 @@
 const setup = require('./include/setup');
 const sinon = require('sinon');
 const BranchSummary = require('../../src/responses/BranchSummary');
+const BranchDeleteSummary = require('../../src/responses/BranchDeleteSummary');
 
 var git, sandbox;
 
@@ -24,13 +25,68 @@ exports.branch = {
       done();
    },
 
-   'delete local branch': function (test) {
-      git.deleteLocalBranch('new-branch', function (err, result) {
+   'delete local branch with -d option': function (test) {
+      git.branch(['-d', 'new-branch'], function (err, branchSummary) {
+        test.ok(
+          branchSummary instanceof BranchDeleteSummary, 
+          'Uses the BranchDeleteSummary response type'
+        );
+        test.equals(null, err);
+        test.same(['branch', '-d', 'new-branch'], setup.theCommandRun());
+        test.equals('new-branch', branchSummary.branch);
+        test.equals('b190102', branchSummary.hash);
+        test.equals(true, branchSummary.success);
+        test.done();
+     });
+
+     setup.closeWith('Deleted branch new-branch (was b190102).');
+   },
+
+   'delete local branch with -D option': function (test) {
+     git.branch(['-D', 'new-branch'], function (err, branchSummary) {
+         test.ok(
+           branchSummary instanceof BranchDeleteSummary, 
+           'Uses the BranchDeleteSummary response type'
+         );
+         test.equals(null, err);
+         test.same(['branch', '-D', 'new-branch'], setup.theCommandRun());
+         test.equals('new-branch', branchSummary.branch);
+         test.equals('b190102', branchSummary.hash);
+         test.equals(true, branchSummary.success);
+         test.done();
+     });
+
+     setup.closeWith('Deleted branch new-branch (was b190102).');
+   },
+
+   'delete local branch with --delete option': function (test) {
+     git.branch(['--delete', 'new-branch'], function (err, branchSummary) {
+         test.ok(
+           branchSummary instanceof BranchDeleteSummary, 
+           'Uses the BranchDeleteSummary response type'
+         );
+         test.equals(null, err);
+         test.same(['branch', '--delete', 'new-branch'], setup.theCommandRun());
+         test.equals('new-branch', branchSummary.branch);
+         test.equals('b190102', branchSummary.hash);
+         test.equals(true, branchSummary.success);
+         test.done();
+     });
+
+     setup.closeWith('Deleted branch new-branch (was b190102).');
+   },
+
+   'delete local branch with #deleteLocalBranch': function (test) {
+      git.deleteLocalBranch('new-branch', function (err, branchSummary) {
+         test.ok(
+           branchSummary instanceof BranchDeleteSummary, 
+           'Uses the BranchDeleteSummary response type'
+         );
          test.equals(null, err);
          test.same(['branch', '-d', 'new-branch'], setup.theCommandRun());
-         test.equals('new-branch', result.branch);
-         test.equals('b190102', result.hash);
-         test.equals(true, result.success);
+         test.equals('new-branch', branchSummary.branch);
+         test.equals('b190102', branchSummary.hash);
+         test.equals(true, branchSummary.success);
          test.done();
       });
 
@@ -38,12 +94,16 @@ exports.branch = {
    },
 
    'delete local branch errors': function (test) {
-      git.deleteLocalBranch('new-branch', function (err, result) {
+      git.deleteLocalBranch('new-branch', function (err, branchSummary) {
+         test.ok(
+           branchSummary instanceof BranchDeleteSummary, 
+           'Uses the BranchDeleteSummary response type'
+         );
          test.equals(null, err);
          test.same(['branch', '-d', 'new-branch'], setup.theCommandRun());
-         test.equals('new-branch', result.branch);
-         test.equals(null, result.hash);
-         test.equals(false, result.success);
+         test.equals('new-branch', branchSummary.branch);
+         test.equals(null, branchSummary.hash);
+         test.equals(false, branchSummary.success);
          test.done();
       });
 

--- a/test/unit/test-branch.js
+++ b/test/unit/test-branch.js
@@ -7,6 +7,23 @@ const BranchDeleteSummary = require('../../src/responses/BranchDeleteSummary');
 
 var git, sandbox;
 
+function branchDeleteLog (branchName) {
+  return 'Deleted branch ' + branchName + ' (was b190102).';
+}
+
+function testBranchDelete (test, options, err, branchSummary) {
+    test.ok(
+      branchSummary instanceof BranchDeleteSummary, 
+      'Uses the BranchDeleteSummary response type'
+    );
+    test.equals(null, err);
+    test.same(['branch'].concat(options), setup.theCommandRun());
+    test.equals('new-branch', branchSummary.branch);
+    test.equals('b190102', branchSummary.hash);
+    test.equals(true, branchSummary.success);
+    test.done();
+}
+
 exports.setUp = function (done) {
    setup.restore();
    sandbox = sinon.sandbox.create();
@@ -26,71 +43,42 @@ exports.branch = {
    },
 
    'delete local branch with -d option': function (test) {
-      git.branch(['-d', 'new-branch'], function (err, branchSummary) {
-        test.ok(
-          branchSummary instanceof BranchDeleteSummary, 
-          'Uses the BranchDeleteSummary response type'
-        );
-        test.equals(null, err);
-        test.same(['branch', '-d', 'new-branch'], setup.theCommandRun());
-        test.equals('new-branch', branchSummary.branch);
-        test.equals('b190102', branchSummary.hash);
-        test.equals(true, branchSummary.success);
-        test.done();
-     });
+     var branchName = 'new-branch';
+     var options = ['-d', branchName];
+     var callback = testBranchDelete.bind(null, test, options);
 
-     setup.closeWith('Deleted branch new-branch (was b190102).');
+     git.branch(options, callback);
+
+     setup.closeWith(branchDeleteLog(branchName));
    },
 
    'delete local branch with -D option': function (test) {
-     git.branch(['-D', 'new-branch'], function (err, branchSummary) {
-         test.ok(
-           branchSummary instanceof BranchDeleteSummary, 
-           'Uses the BranchDeleteSummary response type'
-         );
-         test.equals(null, err);
-         test.same(['branch', '-D', 'new-branch'], setup.theCommandRun());
-         test.equals('new-branch', branchSummary.branch);
-         test.equals('b190102', branchSummary.hash);
-         test.equals(true, branchSummary.success);
-         test.done();
-     });
+     var branchName = 'new-branch';
+     var options = ['-D', branchName];
+     var callback = testBranchDelete.bind(null, test, options);
 
-     setup.closeWith('Deleted branch new-branch (was b190102).');
+     git.branch(options, callback);
+
+     setup.closeWith(branchDeleteLog(branchName));
    },
 
    'delete local branch with --delete option': function (test) {
-     git.branch(['--delete', 'new-branch'], function (err, branchSummary) {
-         test.ok(
-           branchSummary instanceof BranchDeleteSummary, 
-           'Uses the BranchDeleteSummary response type'
-         );
-         test.equals(null, err);
-         test.same(['branch', '--delete', 'new-branch'], setup.theCommandRun());
-         test.equals('new-branch', branchSummary.branch);
-         test.equals('b190102', branchSummary.hash);
-         test.equals(true, branchSummary.success);
-         test.done();
-     });
+     var branchName = 'new-branch';
+     var options = ['--delete', branchName];
+     var callback = testBranchDelete.bind(null, test, options);
 
-     setup.closeWith('Deleted branch new-branch (was b190102).');
+     git.branch(options, callback);
+
+     setup.closeWith(branchDeleteLog(branchName));
    },
 
    'delete local branch with #deleteLocalBranch': function (test) {
-      git.deleteLocalBranch('new-branch', function (err, branchSummary) {
-         test.ok(
-           branchSummary instanceof BranchDeleteSummary, 
-           'Uses the BranchDeleteSummary response type'
-         );
-         test.equals(null, err);
-         test.same(['branch', '-d', 'new-branch'], setup.theCommandRun());
-         test.equals('new-branch', branchSummary.branch);
-         test.equals('b190102', branchSummary.hash);
-         test.equals(true, branchSummary.success);
-         test.done();
-      });
+      var branchName = 'new-branch';
+      var callback = testBranchDelete.bind(null, test, ['-d', branchName]);
 
-      setup.closeWith('Deleted branch new-branch (was b190102).');
+      git.deleteLocalBranch(branchName, callback);
+
+      setup.closeWith(branchDeleteLog(branchName));
    },
 
    'delete local branch errors': function (test) {


### PR DESCRIPTION
This adds support for the git-branch `-D` and `--delete` options as described on issue #169 . 

I'm not sure I've written the unit tests correctly. Is there a better way to define the test once and then call it for each of the delete options? The tests themselves are the same but they depend on a fresh context for each option. I wasn't sure how to wrap the context in an iteration. I had something like this in mind:

```javascript
'delete local branch with options array': function (test) {
    ['-d', '-D', '--delete'].forEach(...)
}
```

Finally, what is the indentation used here? Is it three spaces?