### PR TITLE
fix(diff summary): fix diff summary to always return full paths

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -978,7 +978,7 @@
 
    Git.prototype.diffSummary = function (options, then) {
       var next = Git.trailingFunctionArgument(arguments);
-      var command = ['--stat'];
+      var command = ['--stat=4096'];
 
       if (options && options !== next) {
          command.push.apply(command, [].concat(options));

--- a/test/unit/test-commands.js
+++ b/test/unit/test-commands.js
@@ -88,7 +88,7 @@ exports.diff = {
 
     'with summary': function (test) {
         git.diffSummary(function (err, diffSummary) {
-            test.same(['diff', '--stat'], theCommandRun());
+            test.same(['diff', '--stat=4096'], theCommandRun());
             test.equals(diffSummary.insertions, 1);
             test.equals(diffSummary.deletions, 2);
             test.equals(diffSummary.files.length, 1);
@@ -109,7 +109,7 @@ exports.diff = {
 
     'with summary and options': function (test) {
         git.diffSummary(['opt-a', 'opt-b'], function () {
-            test.same(['diff', '--stat', 'opt-a', 'opt-b'], theCommandRun());
+            test.same(['diff', '--stat=4096', 'opt-a', 'opt-b'], theCommandRun());
             test.done();
         });
 
@@ -121,7 +121,7 @@ exports.diff = {
 
     'with summary and option': function (test) {
         git.diffSummary('opt-a', function () {
-            test.same(['diff', '--stat', 'opt-a'], theCommandRun());
+            test.same(['diff', '--stat=4096', 'opt-a'], theCommandRun());
             test.done();
         });
 
@@ -135,7 +135,7 @@ exports.diff = {
         var diffFileSummary;
 
         git.diffSummary(function (err, diffSummary) {
-            test.same(['diff', '--stat'], theCommandRun());
+            test.same(['diff', '--stat=4096'], theCommandRun());
             test.equals(diffSummary.insertions, 26);
             test.equals(diffSummary.deletions, 0);
             test.equals(diffSummary.files.length, 2);


### PR DESCRIPTION
Currently, when using diff-summary sometimes it trims file paths. This is a fix for it to always return full paths.

# Example
![2017-07-19 16_12_43-package json visual studio code](https://user-images.githubusercontent.com/3908723/28371524-8b8b4164-6c9d-11e7-8636-d26345e91b3f.png)
As you can see here without specifying the `--stat=XXX` value (the one above), it's trimming the file path.
 And even worse, this is done inconsistently, sometimes it gives you full path if you only select one file.

NB: the reason to use 4096 is due to limit for linux (so hopefully it can never go wrong)