### PR TITLE
Add support for omitting (rather than nullifying) the `localPath` arg…

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -177,11 +177,7 @@
     */
    Git.prototype.clone = function (repoPath, localPath, options, then) {
       var next = Git.trailingFunctionArgument(arguments);
-      var command = ['clone'];
-
-      if (Array.isArray(options)) {
-         command.push.apply(command, options);
-      }
+      var command = ['clone'].concat(Git.trailingArrayArgument(arguments));
 
       for (var i = 0, iMax = arguments.length; i < iMax; i++) {
          if (typeof arguments[i] === 'string') {
@@ -1339,6 +1335,16 @@ Please switch to using Git#exec to run arbitrary functions as part of the comman
    Git.trailingOptionsArgument = function (args) {
       var options = args[(args.length - (Git.trailingFunctionArgument(args) ? 2 : 1))];
       return Object.prototype.toString.call(options) === '[object Object]' ? options : null;
+   };
+
+   /**
+    * Given any number of arguments, returns the trailing options array argument, ignoring a trailing function argument
+    * if there is one. When not found, the return value is an empty array.
+    * @returns {Array}
+    */
+   Git.trailingArrayArgument = function (args) {
+      var options = args[(args.length - (Git.trailingFunctionArgument(args) ? 2 : 1))];
+      return Object.prototype.toString.call(options) === '[object Array]' ? options : [];
    };
 
    /**

--- a/test/unit/test-clone.js
+++ b/test/unit/test-clone.js
@@ -55,6 +55,15 @@ exports.clone = {
       closeWith('anything');
    },
 
+   'clone with array of options without local': function (test) {
+      git.clone('repo', ['foo', 'bar'], function (err, data) {
+         test.same(['clone', 'foo', 'bar', 'repo'], theCommandRun());
+         test.done();
+      });
+
+      closeWith('anything');
+   },
+
    'explicit mirror': function (test) {
       git.mirror('r', 'l', function () {
          test.same(['clone', '--mirror', 'r', 'l'], theCommandRun());


### PR DESCRIPTION
…ument from `git.clone` with array of options supplied.

Closes #199