### PR TITLE
fix: change `close` to `exit`

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1350,7 +1350,7 @@ Please switch to using Git#exec to run arbitrary functions as part of the comman
             stdErr.push(new Buffer(err.stack, 'ascii'));
          });
 
-         spawned.on('close', function (exitCode, exitSignal) {
+         spawned.on('exit', function (exitCode, exitSignal) {
             function done (output) {
                then.call(git, null, output);
             }

--- a/test/unit/include/setup.js
+++ b/test/unit/include/setup.js
@@ -61,7 +61,7 @@
       }
 
       mockChildProcesses[mockChildProcesses.length - 1].on.args.forEach(function (handler) {
-         if (handler[0] === 'close') {
+         if (handler[0] === 'exit') {
             handler[1](typeof data === "number" ? data : 0);
          }
       });


### PR DESCRIPTION
https://nodejs.org/api/child_process.html#child_process_event_exit

if underlying ssh connection is configured to `keepalive`, `stdout` will not close after git exit.