### PR TITLE
Update typings with silent() method.

### DIFF
--- a/typings/promise/index.d.ts
+++ b/typings/promise/index.d.ts
@@ -122,6 +122,15 @@ declare namespace simplegit {
 		 * @returns {Promise<TagResult>} Parsed tag list.
 		 */
 		tags(options?: string[]): Promise<TagResult>;
+		
+		/**
+		 * Disables/enables the use of the console for printing warnings and errors, by default messages are not shown in
+		 * a production environment.
+		 *
+		 * @param {boolean} silence
+		 * @returns {Git}
+		 */
+		silent(silence?: boolean): simplegit.SimpleGit;
 	}
 
 


### PR DESCRIPTION
The promise typings currently omit `.silent()`, so Typescript fails to compile.

Adding the types for `.silent()` allowed my project to compile and life to move on 👍 