### PR TITLE
Modify tests for cleaner output and support nodeunit in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "main": "src/index.js",
   "bin": {},
   "scripts": {
-    "test": "node node_modules/nodeunit/bin/nodeunit test/unit/test*.js"
+    "test": "node node_modules/nodeunit/bin/nodeunit test/unit/"
   }
 }

--- a/src/git.js
+++ b/src/git.js
@@ -625,7 +625,7 @@
       var next = Git.trailingFunctionArgument(arguments);
 
       if (!command.length) {
-         return this.then(function () {
+         return this.exec(function () {
             next && next(new Error('Raw: must supply one or more command to execute'), null);
          });
       }
@@ -1149,7 +1149,7 @@
     * @deprecated
     */
    Git.prototype.then = function (then) {
-      console.warn("\n\
+      this._getLog('warn', "\n\
 Git#then is deprecated after version 1.72 and will be removed in version 2.x\n\
 Please switch to using Git#exec to run arbitrary functions as part of the command chain.\n\
 ");

--- a/test/unit/test-check-is-repo.js
+++ b/test/unit/test-check-is-repo.js
@@ -1,13 +1,14 @@
 'use strict';
 
+const {theCommandRun, closeWith, errorWith, hasQueuedTasks, Instance, restore} = require('./include/setup');
 const sinon = require('sinon');
 
-var git, sandbox;
-var {theCommandRun, closeWith, errorWith, hasQueuedTasks, Instance, restore} = require('./include/setup');
+let git, sandbox;
 
 exports.setUp = function (done) {
    restore();
    sandbox = sinon.sandbox.create();
+   sandbox.stub(console, 'error');
    done();
 };
 
@@ -29,6 +30,7 @@ exports.checkIsRepo = {
          test.same(null, err);
          test.same(isRepo, true);
 
+         test.ok(console.error.notCalled, 'generates no error');
          test.done();
       });
 
@@ -40,6 +42,7 @@ exports.checkIsRepo = {
          test.same(null, err);
          test.same(isRepo, false);
 
+         test.ok(console.error.notCalled, 'generates no error');
          test.done();
       });
 
@@ -52,6 +55,7 @@ exports.checkIsRepo = {
       git.checkIsRepo(function (err, isRepo) {
          test.same(errorString, err);
 
+         test.ok(console.error.called, 'generates an error');
          test.done();
       });
 
@@ -64,6 +68,7 @@ exports.checkIsRepo = {
       git.checkIsRepo(function (err, isRepo) {
          test.same(errorString, err);
 
+         test.ok(console.error.called, 'generates an error');
          test.done();
       });
 

--- a/test/unit/test-commands.js
+++ b/test/unit/test-commands.js
@@ -22,6 +22,7 @@ exports.tearDown = function (done) {
 
 exports.childProcess = {
     setUp: function (done) {
+        sandbox.stub(console, 'error');
         git = Instance();
         done();
     },
@@ -473,6 +474,7 @@ exports.show = {
 
 exports.subModule = {
     setUp: function (done) {
+        sandbox.stub(console, 'warn');
         git = Instance();
         done();
     },
@@ -490,6 +492,7 @@ exports.subModule = {
 
     'update with string arg': function (test) {
         git.submoduleUpdate('foo', function (err, result) {
+            test.ok(console.warn.called, 'should warn invalid usage');
             test.equals(null, err, 'not an error');
             test.equals('', result, 'passes through the result');
             test.same(["submodule", "update", "foo"], theCommandRun());
@@ -523,6 +526,7 @@ exports.subModule = {
 
     'init with string arg': function (test) {
         git.submoduleInit('foo', function (err, result) {
+            test.ok(console.warn.called, 'should warn invalid usage');
             test.equals(null, err, 'not an error');
             test.equals('', result, 'passes through the result');
             test.same(["submodule", "init", "foo"], theCommandRun());

--- a/test/unit/test-cwd.js
+++ b/test/unit/test-cwd.js
@@ -1,25 +1,25 @@
 'use strict';
 
-const setup = require('./include/setup');
+const {theCommandRun, restore, Instance, closeWith, errorWith} = require('./include/setup');
 const sinon = require('sinon');
 
-var git, sandbox;
+let git, sandbox;
 
 exports.setUp = function (done) {
-   setup.restore();
+   restore();
    sandbox = sinon.sandbox.create();
    done();
 };
 
 exports.tearDown = function (done) {
-   setup.restore();
+   restore();
    sandbox.restore();
    done();
 };
 
 exports.cwd = {
    setUp: function (done) {
-      git = setup.Instance();
+      git = Instance().silent(true);
       done();
    },
 
@@ -31,7 +31,7 @@ exports.cwd = {
          test.done();
       });
 
-      setup.closeWith('');
+      closeWith('');
    },
 
    'to an invalid directory': function (test) {
@@ -42,6 +42,6 @@ exports.cwd = {
          test.done();
       });
 
-      setup.closeWith('');
+      closeWith('');
    }
 };

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -1,21 +1,22 @@
 'use strict';
 
-const setup = require('./include/setup');
+const {theCommandRun, restore, Instance, closeWith} = require('./include/setup');
 const sinon = require('sinon');
 const ListLogSummary = require('../../src/responses/ListLogSummary');
 
 const commitSplitter = ListLogSummary.COMMIT_BOUNDARY;
 
-var git, sandbox;
+let git, sandbox;
 
 exports.setUp = function (done) {
-   setup.restore();
+   restore();
    sandbox = sinon.sandbox.create();
+   sandbox.stub(console, 'warn');
    done();
 };
 
 exports.tearDown = function (done) {
-   setup.restore();
+   restore();
    sandbox.restore();
    done();
 };
@@ -23,7 +24,7 @@ exports.tearDown = function (done) {
 
 exports.log = {
    setUp: function (done) {
-      git = setup.Instance();
+      git = Instance();
       done();
    },
 
@@ -37,7 +38,7 @@ exports.log = {
          test.done();
       });
 
-      setup.closeWith([
+      closeWith([
          'ca931e641eb2929cf86093893e9a467e90bf4c9b;2016-01-04 18:54:56 +0100;Fix log.latest. (HEAD, stmbgr-master);stmbgr;stmbgr@gmail.com',
          '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805;2016-01-03 16:02:22 +0000;Release 1.20.0 (origin/master, origin/HEAD, master);Steve King;steve@mydev.co',
          'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;2016-01-03 16:02:04 +0000;Support for any parameters to `git log` by supplying `options` as an array (tag: 1.20.0);Steve King;ste',
@@ -48,14 +49,14 @@ exports.log = {
    'uses custom splitter': function (test) {
       git.log({splitter: "::"}, function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", `--pretty=format:%H::%ai::%s%d::%aN::%ae${commitSplitter}`], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H::%ai::%s%d::%aN::%ae${commitSplitter}`], theCommandRun());
          test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.hash, 'knows which is latest');
          test.same(4, result.total, 'picked out all items');
 
          test.done();
       });
 
-      setup.closeWith([
+      closeWith([
          'ca931e641eb2929cf86093893e9a467e90bf4c9b::2016-01-04 18:54:56 +0100::Fix log.latest. (HEAD, stmbgr-master)::stmbgr::stmbgr@gmail.com',
          '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805::2016-01-03 16:02:22 +0000::Release 1.20.0 (origin/master, origin/HEAD, master)::Steve King::steve@mydev.co',
          'd4bdd0c823584519ddd70f8eceb8ff06c0d72324::2016-01-03 16:02:04 +0000::Support for any parameters to `git log` by supplying `options` as an array (tag: 1.20.0)::Steve King::ste',
@@ -66,11 +67,11 @@ exports.log = {
    'with explicit from and to': function (test) {
       git.log('from', 'to', function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "from...to"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "from...to"], theCommandRun());
          test.done();
       });
 
-      setup.closeWith('17df9a7421dd86920cd20afd1d6b6be527a89b88;2015-11-24 11:55:47 +0100;add reset command;Mark Oswald;markoswald123@googlemail.com\n\
+      closeWith('17df9a7421dd86920cd20afd1d6b6be527a89b88;2015-11-24 11:55:47 +0100;add reset command;Mark Oswald;markoswald123@googlemail.com\n\
 4e0d08e0653101fb4d8da3ea3420f5c490401e9e;2015-11-19 22:03:49 +0000;Release 1.12.0 (origin/master, origin/HEAD);Steve King;steve@mydev.co\n\
 83f3f60d5899116fe4d38b9109c9d925963856da;2015-11-19 13:54:28 +0000;Merge pull request #51 from ebaioni/patch-1 (tag: 1.12.0);Steve King;steve@mydev.co\n\
 c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates command to customBinary;Enrico Baioni;baio88@gmail.com\n\
@@ -81,11 +82,11 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
    'with options array': function (test) {
       git.log(['--some=thing'], function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--some=thing"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--some=thing"], theCommandRun());
          test.done();
       });
 
-      setup.closeWith('17df9a7421dd86920cd20afd1d6b6be527a89b88;2015-11-24 11:55:47 +0100;add reset command;Mark Oswald;markoswald123@googlemail.com\n\
+      closeWith('17df9a7421dd86920cd20afd1d6b6be527a89b88;2015-11-24 11:55:47 +0100;add reset command;Mark Oswald;markoswald123@googlemail.com\n\
 4e0d08e0653101fb4d8da3ea3420f5c490401e9e;2015-11-19 22:03:49 +0000;Release 1.12.0 (origin/master, origin/HEAD);Steve King;steve@mydev.co\n\
 83f3f60d5899116fe4d38b9109c9d925963856da;2015-11-19 13:54:28 +0000;Merge pull request #51 from ebaioni/patch-1 (tag: 1.12.0);Steve King;steve@mydev.co\n\
 c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates command to customBinary;Enrico Baioni;baio88@gmail.com\n\
@@ -96,11 +97,11 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
    'with max count shorthand property': function (test) {
       git.log({n: 5}, function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--max-count=5"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--max-count=5"], theCommandRun());
          test.done();
       });
 
-      setup.closeWith('17df9a7421dd86920cd20afd1d6b6be527a89b88;2015-11-24 11:55:47 +0100;add reset command;Mark Oswald;markoswald123@googlemail.com\n\
+      closeWith('17df9a7421dd86920cd20afd1d6b6be527a89b88;2015-11-24 11:55:47 +0100;add reset command;Mark Oswald;markoswald123@googlemail.com\n\
 4e0d08e0653101fb4d8da3ea3420f5c490401e9e;2015-11-19 22:03:49 +0000;Release 1.12.0 (origin/master, origin/HEAD);Steve King;steve@mydev.co\n\
 83f3f60d5899116fe4d38b9109c9d925963856da;2015-11-19 13:54:28 +0000;Merge pull request #51 from ebaioni/patch-1 (tag: 1.12.0);Steve King;steve@mydev.co\n\
 c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates command to customBinary;Enrico Baioni;baio88@gmail.com\n\
@@ -111,11 +112,11 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
    'with max count longhand property': function (test) {
       git.log({n: 5}, function (err, result) {
          test.equals(null, err, 'not an error');
-         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--max-count=5"], setup.theCommandRun());
+         test.same(["log", `--pretty=format:%H;%ai;%s%d;%aN;%ae${commitSplitter}`, "--max-count=5"], theCommandRun());
          test.done();
       });
 
-      setup.closeWith('17df9a7421dd86920cd20afd1d6b6be527a89b88;2015-11-24 11:55:47 +0100;add reset command;Mark Oswald;markoswald123@googlemail.com\n\
+      closeWith('17df9a7421dd86920cd20afd1d6b6be527a89b88;2015-11-24 11:55:47 +0100;add reset command;Mark Oswald;markoswald123@googlemail.com\n\
 4e0d08e0653101fb4d8da3ea3420f5c490401e9e;2015-11-19 22:03:49 +0000;Release 1.12.0 (origin/master, origin/HEAD);Steve King;steve@mydev.co\n\
 83f3f60d5899116fe4d38b9109c9d925963856da;2015-11-19 13:54:28 +0000;Merge pull request #51 from ebaioni/patch-1 (tag: 1.12.0);Steve King;steve@mydev.co\n\
 c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates command to customBinary;Enrico Baioni;baio88@gmail.com\n\
@@ -132,11 +133,11 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
             "--max-count=5",
             "--custom",
             "--custom-with-value=123"
-         ], setup.theCommandRun());
+         ], theCommandRun());
          test.done();
       });
 
-      setup.closeWith('');
+      closeWith('');
    },
 
    'max count appears before file': function (test) {
@@ -148,11 +149,11 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
             "--max-count=10",
             "--follow",
             "/foo/bar.txt"
-         ], setup.theCommandRun());
+         ], theCommandRun());
          test.done();
       });
 
-      setup.closeWith('');
+      closeWith('');
    },
 
    'with custom format option': function (test) {
@@ -167,7 +168,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          test.same([
             "log",
             `--pretty=format:%H;%s;%D${commitSplitter}`
-         ], setup.theCommandRun());
+         ], theCommandRun());
          test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.myhash, 'custom field name');
          test.same('Fix log.latest.', result.latest.message);
          test.same('HEAD, stmbgr-master', result.latest.refs);
@@ -175,7 +176,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
       });
 
 
-      setup.closeWith([
+      closeWith([
            'ca931e641eb2929cf86093893e9a467e90bf4c9b;Fix log.latest.;HEAD, stmbgr-master',
          '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805;Release 1.20.0;origin/master, origin/HEAD, master',
          'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;Support for any parameters to `git log` by supplying `options` as an array;tag: 1.20.0',
@@ -196,7 +197,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          test.same([
             "log",
             `--pretty=format:%H;%b;%D${commitSplitter}`
-         ], setup.theCommandRun());
+         ], theCommandRun());
          test.same('ca931e641eb2929cf86093893e9a467e90bf4c9b', result.latest.myhash, 'custom field name');
          test.same('Fix log.latest.\n\nDescribe the fix', result.latest.message);
          test.same('HEAD, stmbgr-master', result.latest.refs);
@@ -205,7 +206,7 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
       });
 
 
-      setup.closeWith([
+      closeWith([
          "ca931e641eb2929cf86093893e9a467e90bf4c9b;Fix log.latest.\n\nDescribe the fix;HEAD, stmbgr-master",
          '8655cb1cf2a3d6b83f4e6f7ff50ee0569758e805;Release 1.20.0;origin/master, origin/HEAD, master',
          'd4bdd0c823584519ddd70f8eceb8ff06c0d72324;Support for any parameters to `git log` by supplying `options` as an array;tag: 1.20.0' + commitSplitter,
@@ -223,14 +224,14 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
          test.same([
             "log",
             `--pretty=format:%b${commitSplitter}`
-         ], setup.theCommandRun());
+         ], theCommandRun());
          test.same('Fix log.latest.\n\nDescribe the fix', result.latest.message);
          test.same('Release 1.19.0', result.all.slice(-1)[0].message);
          test.done();
       });
 
 
-      setup.closeWith([
+      closeWith([
          "Fix log.latest.\n\nDescribe the fix",
          'Release 1.20.0',
          'Support for any parameters to `git log` by supplying `options` as an array',
@@ -240,14 +241,14 @@ c515d3f28f587312d816e14ef04db399b7e0adcd;2015-11-19 15:55:41 +1100;updates comma
    },
 
    'parses regular log': function (test) {
-      var text = `
+      const text = `
 a9d0113c896c69d24583f567030fa5a8053f6893||Add support for 'git.raw' (origin/add_raw, add_raw)${commitSplitter}
 d8cb111160e0a5925ef9b0bf21abda96d87fdc83||Merge remote-tracking branch 'origin/master' into add_raw${commitSplitter}
 204f2fd1d77ee5f8475c47f44acc8014d7534b00||Add support for 'git.raw'${commitSplitter}
 1dde94c3a06b6e9b7cc88fb32ee23d79eaf39aa6||Merge pull request #143 from steveukx/integration-test${commitSplitter}
 8b613d080027354d4e8427d93b3f839ebb38c39a||Add broken-chain tests${commitSplitter}
 `;
-      var listLogSummary = ListLogSummary.parse(text, '||', ['hash', 'message']);
+      const listLogSummary = ListLogSummary.parse(text, '||', ['hash', 'message']);
       test.equals(listLogSummary.total, 5);
       test.deepEqual(listLogSummary.latest, {
          hash: 'a9d0113c896c69d24583f567030fa5a8053f6893',

--- a/test/unit/test-merge.js
+++ b/test/unit/test-merge.js
@@ -9,6 +9,7 @@ var git, sandbox;
 exports.setUp = function (done) {
    restore();
    sandbox = sinon.sandbox.create();
+   sandbox.stub(console, 'error');
    done();
 };
 

--- a/test/unit/test-raw.js
+++ b/test/unit/test-raw.js
@@ -1,25 +1,26 @@
 'use strict';
 
-const setup = require('./include/setup');
+const {theCommandRun, restore, Instance, closeWith, errorWith} = require('./include/setup');
 const sinon = require('sinon');
 
-var git, sandbox;
+let git, sandbox;
 
 exports.setUp = function (done) {
-   setup.restore();
+   restore();
    sandbox = sinon.sandbox.create();
+   sandbox.stub(console, 'warn');
    done();
 };
 
 exports.tearDown = function (done) {
-   setup.restore();
+   restore();
    sandbox.restore();
    done();
 };
 
 exports.raw = {
    setUp: function (done) {
-      git = setup.Instance();
+      git = Instance();
       done();
    },
 
@@ -27,22 +28,22 @@ exports.raw = {
       git.raw(['abc', 'def'], function (err, result) {
          test.equal(err, null);
          test.equal(result, 'passed through raw response');
-         test.deepEqual(setup.theCommandRun(), ['abc', 'def']);
+         test.deepEqual(theCommandRun(), ['abc', 'def']);
 
          test.done();
       });
-      setup.closeWith('passed through raw response');
+      closeWith('passed through raw response');
    },
 
    'accepts an options object': function (test) {
       git.raw({'abc': 'def'}, function (err, result) {
          test.equal(err, null);
          test.equal(result, 'another raw response');
-         test.deepEqual(setup.theCommandRun(), ['abc=def']);
+         test.deepEqual(theCommandRun(), ['abc=def']);
 
          test.done();
       });
-      setup.closeWith('another raw response');
+      closeWith('another raw response');
    },
 
    'treats empty options as an error': function (test) {
@@ -53,22 +54,23 @@ exports.raw = {
          test.done();
       });
 
-      setup.closeWith('');
+      closeWith('');
    },
 
    'does not require a callback in success': function (test) {
       git.raw(['something']);
       test.doesNotThrow(function () {
-         setup.closeWith('');
-         test.deepEqual(['something'], setup.theCommandRun());
+         closeWith('');
+         test.deepEqual(['something'], theCommandRun());
       });
+      test.ok(console.warn.notCalled, 'Should not have generated any warnings');
       test.done();
    },
 
    'does not require a callback': function (test) {
       git.raw([]);
       test.doesNotThrow(function () {
-         setup.closeWith('');
+         closeWith('');
       });
       test.done();
    }


### PR DESCRIPTION
Remove deprecated use of `.then` in exception handling of commands run through `.raw`
Use consistent importing of setup helpers in the tests
Use directory root for tests in the `npm test` command to allow for running tests on Windows

Closes #234