### PR TITLE
gitignore: corrected the exclusion pattern for typings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules/
 *.bak
 *.log
 *.d.ts
-!typings/*
+!typings/**/*.d.ts


### PR DESCRIPTION
it did not excluded files in subfolders, now it does