### PR TITLE
Use close event instead of exit event as it also works on very fast

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1377,7 +1377,7 @@ Please switch to using Git#exec to run arbitrary functions as part of the comman
             stdErr.push(new Buffer(err.stack, 'ascii'));
          });
 
-         spawned.on('exit', function (exitCode, exitSignal) {
+         spawned.on('close', function (exitCode, exitSignal) {
             function done (output) {
                then.call(git, null, output);
             }


### PR DESCRIPTION
machines. See https://stackoverflow.com/questions/26446791/node-read-spawn-stderr-stdout-after-quick-exit-event