### PR TITLE
Respond to both close and exit events in the underlying child process

### DIFF
--- a/src/util/deferred.js
+++ b/src/util/deferred.js
@@ -1,0 +1,10 @@
+
+module.exports = function deferred () {
+   var d = {};
+   d.promise = new Promise(function (resolve, reject) {
+      d.resolve = resolve;
+      d.reject = reject
+   });
+
+   return d;
+};

--- a/test/unit/test-commands.js
+++ b/test/unit/test-commands.js
@@ -6,7 +6,8 @@ const commitSplitter = '------------------------ >8 ------------------------';
 var sandbox = null;
 var git = null;
 
-const {Instance, closeWith, errorWith, theCommandRun, theEnvironmentVariables, restore} = require('./include/setup');
+const {Instance, childProcessEmits, closeWith, errorWith, theCommandRun, theEnvironmentVariables, restore} =
+   require('./include/setup');
 
 exports.setUp = function (done) {
     sandbox = sinon.sandbox.create();
@@ -310,23 +311,25 @@ exports.revParse = {
         var then = sinon.spy();
         git.revparse('HEAD', then);
 
-        closeWith('');
-        test.ok(then.calledOnce);
-        test.ok(then.calledWith(null, ''));
-        test.ok(console.warn.calledOnce);
+        closeWith('').then(() => {
+           test.ok(then.calledOnce);
+           test.ok(then.calledWith(null, ''));
+           test.ok(console.warn.calledOnce);
 
-        test.done();
+           test.done();
+        });
     },
 
     'valid usage': function (test) {
         var then = sinon.spy();
         git.revparse(['HEAD'], then);
 
-        closeWith('');
-        test.ok(then.calledOnce);
-        test.ok(then.calledWith(null, ''));
-        test.ok(console.warn.notCalled);
-        test.done();
+        closeWith('').then(() => {
+           test.ok(then.calledOnce);
+           test.ok(then.calledWith(null, ''));
+           test.ok(console.warn.notCalled);
+           test.done();
+        });
     },
 
     'called with a string': function (test) {


### PR DESCRIPTION
Allow either the close or exit events on the child process to trigger the termination of that step of the tasks to be run.

In some cases (eg when keep-alive is used on the git connection), exit will emit but close will not (see 777ecfaa9a20ff5d843c43caf3242901497a6c3f).

In others, close will be emitted but not exit (see #252).

This change permits either to be used.