### PR TITLE
Case insensitive check for `Not a git repository`

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1297,7 +1297,7 @@ Please switch to using Git#exec to run arbitrary functions as part of the comman
     */
    Git.prototype.checkIsRepo = function (then) {
       function onError (exitCode, stdErr, done, fail) {
-         if (exitCode === 128 && /Not a git repository/.test(stdErr)) {
+         if (exitCode === 128 && /Not a git repository/i.test(stdErr)) {
             return done(false);
          }
 


### PR DESCRIPTION
Adding the `/i` to the will also match `not a git repository` which is returned on some git versions.  Otherwise `checkIsRepo` will throw an error when the error return is not exactly  `Not a git repository`.