### PR TITLE
Fix TS typings for the getRemotes command

### DIFF
--- a/typings/promise/index.d.ts
+++ b/typings/promise/index.d.ts
@@ -235,7 +235,7 @@ declare namespace simplegit {
        * @param {boolean} [verbose=false]
        */
       getRemotes(verbose: false | undefined): Promise<resp.RemoteWithoutRefs[]>;
-      getRemotes(verbose: true): Promise<resp.RemoteWithRefs>;
+      getRemotes(verbose: true): Promise<resp.RemoteWithRefs[]>;
 
       /**
        * Initialize a git repo


### PR DESCRIPTION
If you pass true to getRemotes it still returns an array even if there is only one remote. The return type for both function signatures should reflect that.