### PR TITLE
Adds the NodeJS namespace to ReadableStream. Fixes #282.

### DIFF
--- a/typings/promise/index.d.ts
+++ b/typings/promise/index.d.ts
@@ -561,8 +561,8 @@ declare namespace simplegit {
 
    type outputHandler = (
       command: string,
-      stdout: ReadableStream,
-      stderr: ReadableStream
+      stdout: NodeJS.ReadableStream,
+      stderr: NodeJS.ReadableStream
    ) => void
 }
 


### PR DESCRIPTION
Bizarrely, while fixing this VS Code suddenly wasn't having any issue with the non-prefixed `ReadableStream` type, so, I *think* this fixes #282? 🤷‍♂️ 