### PR TITLE
fix: Remove default value from init() declaration

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -242,7 +242,7 @@ declare namespace simplegit {
        *
        * @param {Boolean} [bare=false]
        */
-      init(bare = false): Promise<void>;
+      init(bare?: boolean): Promise<void>;
 
       /**
        * List remote


### PR DESCRIPTION
When building my TS project with simple-git 1.102.0 I got the following error:

```
error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
245       init(bare = false): Promise<void>;
```

This PR fixes that.