### PR TITLE
Fix declaration file error

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -242,7 +242,7 @@ declare namespace simplegit {
        *
        * @param {Boolean} [bare=false]
        */
-      init(bare = false): Promise<void>;
+      init(bare?: boolean): Promise<void>;
 
       /**
        * List remote


### PR DESCRIPTION
TS declaration files cannot contain implementation details like as default
values, they can only indicate whether the value is optional or not.

Fixes #312