### PR TITLE
Concurrent commands

### DIFF
--- a/test/integration/include/runner.js
+++ b/test/integration/include/runner.js
@@ -1,10 +1,25 @@
 'use strict';
 
 const FS = require('fs');
+const PATH = require('path');
 
 module.exports = function Test (setup, test) {
 
    let context = {
+      dir (path) {
+         const dir = PATH.join(context.root, path);
+         if (!FS.existsSync(dir)) {
+            FS.mkdirSync(dir);
+         }
+
+         return dir;
+      },
+      file (dir, path, content) {
+         const file = PATH.join(context.dir(dir), path);
+         FS.writeFileSync(file, content, 'utf8');
+
+         return file;
+      },
       root: FS.mkdtempSync((process.env.TMPDIR || '/tmp/') + 'simple-git-test-'),
       git: require('../../../'),
       gitP: require('../../../promise'),

--- a/test/integration/test-concurrent-commands.js
+++ b/test/integration/test-concurrent-commands.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const Test = require('./include/runner');
+
+function delay () {
+   return new Promise(ok => setTimeout(ok, 50));
+}
+
+const setUp = (context) => {
+
+   return Promise.all([
+      configure('first'),
+      configure('second'),
+   ]);
+
+   function configure (thing) {
+      const git = context.gitP(context.dir(thing));
+      context.file(thing, thing, '');
+
+      return git.init()
+         .then(() => git.add(thing))
+         .then(() => git.commit(thing))
+         .then(() => git.raw(['checkout', '-b', thing]))
+         .then(() => delay())
+         ;
+   }
+};
+
+
+const test = (context, assert) => {
+
+   function assertion (dir) {
+      return context.gitP(context.dir(dir)).branchLocal()
+         .then((result) => ({
+            dir,
+            result,
+         }));
+   }
+
+   const result = Promise.all([
+      assertion('first'),
+      assertion('second'),
+      assertion('first'),
+      assertion('second'),
+      assertion('first'),
+      assertion('second'),
+      assertion('first'),
+      assertion('second'),
+   ]);
+
+   return result.then(function (tests) {
+
+      assert.equal(8, tests.length, 'Ran all tests');
+      tests.forEach((test, index) => {
+         assert.equal(
+            test.dir, test.result.current, `Recognised the correct branch name for ${ index }`);
+      });
+
+   });
+};
+
+module.exports = new Test(setUp, test);


### PR DESCRIPTION
Concurrently run commands can fail due to the close/exit events on the ChildProcess firing before data has been read into the stdOut/stdErr buffer.

When one fires without having received data, this change adds a timeout to allow for the next data event to finish processing before handling the child process closing.

(note: not guaranteed to always fix the errors).