### PR TITLE
Add tests to cover the instantiation of the promise wrapped library with an invalid root folder.

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -4,72 +4,80 @@ if (typeof Promise === 'undefined') {
    throw new ReferenceError("Promise wrappers must be enabled to use the promise API");
 }
 
-function asyncWrapper (fn, git, chain) {
-   return function () {
-      var args = [].slice.call(arguments);
-
-      if (typeof args[args.length] === 'function') {
-         throw new TypeError(
-            "Promise interface requires that handlers are not supplied inline, " +
-            "trailing function not allowed in call to " + fn);
-      }
-
-      return chain.then(function () {
-         return new Promise(function (resolve, reject) {
-            args.push(function (err, result) {
-               if (err) {
-                  reject(new Error(err));
-               }
-               else {
-                  resolve(result);
-               }
-            });
-
-            git[fn].apply(git, args);
-         });
-      });
-   };
-}
-
-function syncWrapper (fn, git, api) {
-   return function () {
-      git[fn].apply(git, arguments);
-
-      return api;
-   };
-}
-
 function isAsyncCall (fn) {
    return /^[^\)]+then\s*\)/.test(fn) || /\._run\(/.test(fn);
 }
 
 module.exports = function (baseDir) {
 
+   var Git = require('./src/git');
+   var gitFactory = require('./src');
    var git;
+
+
    var chain = Promise.resolve();
 
    try {
-      git = require('./src')(baseDir);
+      git = gitFactory(baseDir);
    }
    catch (e) {
       chain = Promise.reject(e);
    }
 
-   return Object.keys(git.constructor.prototype).reduce(function (api, fn) {
+   return Object.keys(Git.prototype).reduce(function (promiseApi, fn) {
       if (/^_|then/.test(fn)) {
-         return api;
+         return promiseApi;
       }
 
-      if (isAsyncCall(git[fn])) {
-         api[fn] = asyncWrapper(fn, git, chain);
+      if (isAsyncCall(Git.prototype[fn])) {
+         promiseApi[fn] = git ? asyncWrapper(fn, git) : function () {
+            return chain;
+         };
       }
 
       else {
-         api[fn] = syncWrapper(fn, git, api);
+         promiseApi[fn] = git ? syncWrapper(fn, git, promiseApi) : function () {
+            return promiseApi;
+         };
       }
 
-      return api;
+      return promiseApi;
 
    }, {});
+
+   function asyncWrapper (fn, git) {
+      return function () {
+         var args = [].slice.call(arguments);
+
+         if (typeof args[args.length] === 'function') {
+            throw new TypeError(
+               "Promise interface requires that handlers are not supplied inline, " +
+               "trailing function not allowed in call to " + fn);
+         }
+
+         return chain.then(function () {
+            return new Promise(function (resolve, reject) {
+               args.push(function (err, result) {
+                  if (err) {
+                     reject(new Error(err));
+                  }
+                  else {
+                     resolve(result);
+                  }
+               });
+
+               git[fn].apply(git, args);
+            });
+         });
+      };
+   }
+
+   function syncWrapper (fn, git, api) {
+      return function () {
+         git[fn].apply(git, arguments);
+
+         return api;
+      };
+   }
 
 };

--- a/test/integration/test-promise-on-bad-path.js
+++ b/test/integration/test-promise-on-bad-path.js
@@ -1,0 +1,26 @@
+/*
+   This test covers creating a promise API wrapped instance of the library on a directory that does not exist
+ */
+const Test = require('./include/runner');
+const Path = require('path');
+
+const setUp = (context) => {
+   return Promise.resolve();
+};
+
+module.exports = {
+   'promise': new Test(setUp, (context, assert) => {
+      let result = context.deferred();
+
+      let git = context.gitP(Path.join(context.root, 'foo')).silent(true);
+
+      git.status()
+         .then(() => result.resolve(new Error('Should have been an error when constructing')))
+         .catch((e) => {
+            assert.ok(!!e, 'Was an error when constructing');
+            result.resolve();
+         });
+
+      return result.promise;
+   })
+};


### PR DESCRIPTION

Closes #344
Closes #336