### PR TITLE
Issue #286: Add "two dot" notation for "git log".

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1234,6 +1234,7 @@
          author_name: '%aN',
          author_email: '%ae'
       };
+      var rangeOperator = (opt.symmetric === undefined ? true : opt.symmetric) ? '...' : '..';
 
       var fields = Object.keys(format);
       var formatstr = fields.map(function (k) {
@@ -1259,14 +1260,14 @@
       }
 
       if (opt.from && opt.to) {
-         command.push(opt.from + "..." + opt.to);
+         command.push(opt.from + rangeOperator + opt.to);
       }
 
       if (opt.file) {
          command.push("--follow", options.file);
       }
 
-      'splitter n max-count file from to --pretty format'.split(' ').forEach(function (key) {
+      'splitter n max-count file from to --pretty format symmetric'.split(' ').forEach(function (key) {
          delete opt[key];
       });
 

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -273,6 +273,7 @@ e613462dc8384deab7c4046e7bc8b5370a295e14;2019-03-23 07:24:21 +0000;Change name o
          format: {
             'message': '%b',
          },
+         symmetric: false,
          '--reflog': null,
          '--stat-width': '10',
       };

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -65,7 +65,21 @@ exports.log = {
    },
 
    'with explicit from and to' (test) {
-      git.log('from', 'to', function (err, result) {
+      git.log('from', 'to', function (err) {
+         test.equals(null, err, 'not an error');
+         test.same(["log", `--pretty=format:%H;%ai;%s;%D;%b;%aN;%ae${commitSplitter}`, "from...to"], theCommandRun());
+         test.done();
+      });
+
+      closeWith('');
+   },
+
+   'with non-symmetric from and to' (test) {
+      git.log({
+         from: 'from',
+         to: 'to',
+         symmetric: true
+      }, function (err, result) {
          test.equals(null, err, 'not an error');
          test.same(["log", `--pretty=format:%H;%ai;%s;%D;%b;%aN;%ae${commitSplitter}`, "from...to"], theCommandRun());
          test.done();


### PR DESCRIPTION
To be compatible, the default value of option "symmetric" is true. If its value is false, then it should use two-dot notation (..).