### PR TITLE
add `windowsHide: true` option when spawning child process

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1412,7 +1412,8 @@
          var stdErr = [];
          var spawned = git.ChildProcess.spawn(git._command, command.slice(0), {
             cwd: git._baseDir,
-            env: git._env
+            env: git._env,
+            windowsHide: true
          });
 
          spawned.stdout.on('data', function (buffer) {


### PR DESCRIPTION
On Windows, using `git-js` in a script stated with `forever` causes terminal window popups, similarly to this issue: https://github.com/foreversd/forever/issues/767. Setting `windowsHide` option to `true` fixes it.