### PR TITLE
Add integration test for multi-line comments in a log summary

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,11 @@ There are a few potential reasons:
   with the `.customBinary(...)` api option.
 - the working directory passed in to the main `simple-git` function isn't accessible, check it is read/write accessible
   by the user running the `node` process.
+  
+### Log response properties are out of order
+
+The properties of `git.log` are fetched using a `;` as a delimiter. If your commit messages use the `;` character,
+supply a custom `splitter` in the options, for example: `git.log({ splitter: '|||' })` 
 
 # Examples
 

--- a/test/integration/test-log.js
+++ b/test/integration/test-log.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const Test = require('./include/runner');
+
+const setUp = (context) => {
+
+   const repo = context.gitP(context.root);
+   return repo.init()
+      .then(() => context.file('src', 'a.txt', 'fie content'))
+      .then(() => repo.add('src/a.txt'))
+      .then(() => repo.commit('commit line one\ncommit line two\n'))
+      .then(() => context.file('src', 'b.txt', 'fie content'))
+      .then(() => repo.add('src/b.txt'))
+      .then(() => repo.commit('commit on one line'))
+      .then((commit) => context.commit = commit)
+      .then(() => repo.raw(['config', 'user.name']).then(data => context.$userName = data.trim()))
+      .then(() => repo.raw(['config', 'user.email']).then(data => context.$userEmail = data.trim()))
+      ;
+};
+
+module.exports = {
+
+   'multi-line commit message in log summary': new Test(setUp, (context, assert) => {
+      return context.gitP(context.root).log({ multiLine: true })
+         .then((actual) => {
+            assert.same(actual.latest, actual.all[0]);
+            assert.same(actual.latest.refs, 'HEAD -> master');
+            assert.same(actual.latest.body, 'commit on one line\n');
+            assert.same(actual.latest.author_name, context.$userName);
+            assert.same(actual.latest.author_email, context.$userEmail);
+         });
+
+   }),
+
+   'multi-line commit message in custom format log summary': new Test(setUp, (context, assert) => {
+      return context.gitP(context.root).log({ format: { refs: '%D', body: '%B', message: '%s' }, splitter: '||' })
+         .then((actual) => {
+            assert.deepEqual(actual.all[0], {
+               body: 'commit on one line\n',
+               refs: 'HEAD -> master',
+               message: 'commit on one line',
+            });
+            assert.deepEqual(actual.all[1], {
+               body: 'commit line one\ncommit line two\n',
+               refs: '',
+               message: 'commit line one commit line two',
+            });
+         });
+
+   }),
+
+
+};


### PR DESCRIPTION
Integration test for multi-line commit messages in a log summary

Closes #376 