### PR TITLE
Follow option in git.log

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1224,6 +1224,7 @@
       var formatstr = fields.map(function (k) {
          return format[k];
       }).join(splitter);
+      var suffix = [];
       var command = ["log", "--pretty=format:"
          + requireResponseHandler('ListLogSummary').START_BOUNDARY
          + formatstr
@@ -1252,7 +1253,7 @@
       }
 
       if (opt.file) {
-         command.push("--follow", options.file);
+         suffix.push("--follow", options.file);
       }
 
       'splitter n max-count file from to --pretty format symmetric multiLine'.split(' ').forEach(function (key) {
@@ -1261,7 +1262,10 @@
 
       Git._appendOptions(command, opt);
 
-      return this._run(command, Git._responseHandler(handler, 'ListLogSummary', [splitter, fields]));
+      return this._run(
+         command.concat(suffix),
+         Git._responseHandler(handler, 'ListLogSummary', [splitter, fields])
+      );
    };
 
    /**

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -29,6 +29,15 @@ exports.logP = {
       done();
    },
 
+   async 'follow option is added as a suffix' (test) {
+      closeWithP('');
+      await git.log({file: 'index.js', format: { hash: '%H' }, '--fixed-strings': true});
+
+      test.same(['log', `--pretty=format:${ START_BOUNDARY }%H${COMMIT_BOUNDARY}`, '--fixed-strings', '--follow', 'index.js'], theCommandRun());
+      test.done();
+   },
+
+
    'with stat=4096 and custom format / splitter' (test) {
       git.log({'--stat': '4096', 'splitter': ' !! ', 'format': { hash: '%H', author: '%aN' }}).then(log => {
 


### PR DESCRIPTION
Force `--follow` to be appended to the set of supplied options in a `git.log`

Closes #389