### PR TITLE
Make options argument of branch method optional

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -61,7 +61,7 @@ declare namespace simplegit {
        * @param {Object | string[]} [options]
        * @returns {Promise<BranchSummary>}
        */
-      branch(options: Options | string[]): Promise<BranchSummary>;
+      branch(options?: Options | string[]): Promise<BranchSummary>;
 
       /**
        * List of local branches


### PR DESCRIPTION
Corrects the typescript declaration file so the options argument of the branch method is set to be optional (as described in the docs).