### PR TITLE
Correct BranchSummary declaration

### DIFF
--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -10,7 +10,7 @@ export interface BranchDeletionSummary {
    current: string;
    all: string[];
    branches: {[key: string]: {
-      current: string,
+      current: boolean,
       name: string,
       commit: string,
       label: string


### PR DESCRIPTION
The property current of branch objects actually is of type boolean.
See here for the instantiation:
https://github.com/steveukx/git-js/blob/031ace112417034c0f1b60abaa399decdcafb5b0/src/responses/BranchSummary.js#L42