### PR TITLE
If two branches have added the same file with conflicts. It should be added to StatusSummary.conflicted.

### DIFF
--- a/src/responses/StatusSummary.js
+++ b/src/responses/StatusSummary.js
@@ -125,6 +125,7 @@ StatusSummary.parsers = {
 };
 
 StatusSummary.parsers.MM = StatusSummary.parsers.M;
+StatusSummary.parsers.AA = StatusSummary.parsers.UU;
 
 StatusSummary.parse = function (text) {
    var file;

--- a/test/unit/test-status.js
+++ b/test/unit/test-status.js
@@ -180,5 +180,11 @@ R  src/a.txt -> src/c.txt
       setup.closeWith(' M src/git_wd.js\n\
 MM src/git_ind_wd.js\n\
 M  src/git_ind.js\n');
-   }
+   },
+
+   'Report conflict when both sides have added the same file': function (test) {
+        let statusSummary = StatusSummary.parse(`## master\nAA filename`);
+        test.deepEqual(statusSummary.conflicted, ['filename']);
+        test.done();
+    },
 };


### PR DESCRIPTION
If two branches have added a new file with the same name and the content can't be automatically merged the file is not added in StatusSummary.conflicted.

Both sides have added the file conflict2.txt
```
$ git status --porcelain -b -u
## master
AA conflict2.txt
```