### PR TITLE
Parse and report modify delete conflicts

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -298,7 +298,7 @@ declare namespace simplegit {
        * @see https://github.com/steveukx/git-js/blob/master/src/responses/MergeSummary.js
        * @see https://github.com/steveukx/git-js/blob/master/src/responses/PullSummary.js
        */
-      merge(options: Options | string[]): Promise<any>;
+      merge(options: Options | string[]): Promise<MergeSummary>;
 
       /**
        * Merges from one branch to another, equivalent to running `git merge ${from} $[to}`, the `options` argument can
@@ -555,6 +555,8 @@ declare namespace simplegit {
    interface BranchSummary extends resp.BranchSummary {}
 
    interface CommitSummary extends resp.CommitSummary {}
+
+   interface MergeSummary extends resp.MergeSummary {}
 
    interface PullResult extends resp.PullResult {}
 

--- a/src/responses/StatusSummary.js
+++ b/src/responses/StatusSummary.js
@@ -125,7 +125,14 @@ StatusSummary.parsers = {
 };
 
 StatusSummary.parsers.MM = StatusSummary.parsers.M;
+
+/* Map all unmerged status code combinations to UU to mark as conflicted */
 StatusSummary.parsers.AA = StatusSummary.parsers.UU;
+StatusSummary.parsers.UD = StatusSummary.parsers.UU;
+StatusSummary.parsers.DU = StatusSummary.parsers.UU;
+StatusSummary.parsers.DD = StatusSummary.parsers.UU;
+StatusSummary.parsers.AU = StatusSummary.parsers.UU;
+StatusSummary.parsers.UA = StatusSummary.parsers.UU;
 
 StatusSummary.parse = function (text) {
    var file;

--- a/test/unit/test-merge.js
+++ b/test/unit/test-merge.js
@@ -75,6 +75,41 @@ Automatic merge failed; fix conflicts and then commit the result.
       test.done();
    },
 
+   'names modify/delete conflicts when deleted by them': function (test) {
+      const mergeSummary = MergeSummary.parse(`
+Auto-merging readme.md
+CONFLICT (modify/delete): readme.md deleted in origin/master and modified in HEAD. Version HEAD of readme.md left in tree.
+Automatic merge failed; fix conflicts and then commit the result.
+`);
+      test.same(mergeSummary.failed, true);
+      test.same(mergeSummary.conflicts, [
+         {
+            reason: 'modify/delete',
+            file: 'readme.md',
+            meta: { deleteRef: 'origin/master' }
+         }
+      ]);
+      test.done();
+   },
+
+   'names modify/delete conflicts when deleted by us': function (test) {
+      const mergeSummary = MergeSummary.parse(`
+Auto-merging readme.md
+CONFLICT (modify/delete): readme.md deleted in HEAD and modified in origin/master. Version origin/master of readme.md left in tree.
+Automatic merge failed; fix conflicts and then commit the result.
+`);
+
+      test.same(mergeSummary.failed, true);
+      test.same(mergeSummary.conflicts, [
+         {
+            reason: 'modify/delete',
+            file: 'readme.md',
+            meta: { deleteRef: 'HEAD' }
+         }
+      ]);
+      test.done();
+   },
+
    'merge with fatal error': function (test) {
       git.mergeFromTo('aaa', 'bbb', 'x', function (err, mergeSummary) {
          test.same(null, mergeSummary);

--- a/test/unit/test-status.js
+++ b/test/unit/test-status.js
@@ -183,8 +183,22 @@ M  src/git_ind.js\n');
    },
 
    'Report conflict when both sides have added the same file': function (test) {
-        let statusSummary = StatusSummary.parse(`## master\nAA filename`);
-        test.deepEqual(statusSummary.conflicted, ['filename']);
-        test.done();
-    },
+      let statusSummary = StatusSummary.parse(`## master\nAA filename`);
+      test.deepEqual(statusSummary.conflicted, ['filename']);
+      test.done();
+   },
+   'Report all types of merge conflict statuses': function (test) {
+      const summary = StatusSummary.parse(`
+            UU package.json
+            DD src/git.js
+            DU src/index.js
+            UD src/newfile.js
+            AU test.js
+            UA test
+            AA test-foo.js
+      `);
+
+      test.deepEqual(summary.conflicted, ['package.json', 'src/git.js', 'src/index.js', 'src/newfile.js', 'test.js', 'test', 'test-foo.js'], 'Files in conflict');
+      test.done();
+   },
 };

--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -117,6 +117,18 @@ export interface StatusResultRenamed {
    to: string;
 }
 
+export interface FileStatusSumary {
+   /* Path of the file */
+   path: string;
+   /* First digit of the status code of the file, e.g. 'M' = modified.
+      Represents the status of the index if no merge conflicts, otherwise represents
+      status of one side of the merge. */
+   index: string;
+   /* Second digit of the status code of the file. Represents status of the working directory
+      if no merge conflicts, otherwise represents status of other side of a merge. */
+   working_dir: string;
+}
+
 export interface StatusResult {
    not_added: string[];
    conflicted: string[];
@@ -125,11 +137,7 @@ export interface StatusResult {
    modified: string[];
    renamed: StatusResultRenamed[];
    staged: string[];
-   files: {
-      path: string;
-      index: string;
-      working_dir: string;
-   }[];
+   files: FileStatusSumary[];
    ahead: number;
    behind: number;
    current: string;

--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -1,21 +1,22 @@
-
 export interface BranchDeletionSummary {
    branch: string;
    hash: any;
    success: boolean;
 }
 
- export interface BranchSummary {
+export interface BranchSummary {
    detached: boolean;
    current: string;
    all: string[];
-   branches: {[key: string]: {
-      current: boolean,
-      name: string,
-      commit: string,
-      label: string
-   }};
- }
+   branches: {
+      [key: string]: {
+         current: boolean;
+         name: string;
+         commit: string;
+         label: string;
+      };
+   };
+}
 
 export interface CommitSummary {
    author: null | {
@@ -32,11 +33,11 @@ export interface CommitSummary {
 }
 
 export interface DiffResultTextFile {
-    file: string;
-    changes: number,
-    insertions: number;
-    deletions: number;
-    binary: boolean;
+   file: string;
+   changes: number;
+   insertions: number;
+   deletions: number;
+   binary: boolean;
 }
 
 export interface DiffResultBinaryFile {
@@ -78,12 +79,11 @@ export interface MoveSummary {
 }
 
 export interface PullResult {
-
    /** Array of all files that are referenced in the pull */
    files: string[];
 
    /** Map of file names to the number of insertions in that file */
-   insertions: {[key: string]: number};
+   insertions: { [key: string]: number };
 
    /** Map of file names to the number of deletions in that file */
    deletions: any;
@@ -109,7 +109,7 @@ export interface RemoteWithRefs extends RemoteWithoutRefs {
    refs: {
       fetch: string;
       push: string;
-   }
+   };
 }
 
 export interface StatusResultRenamed {
@@ -162,7 +162,6 @@ export interface DefaultLogFields {
  * properties are dependent on the command used.
  */
 export interface ListLogLine {
-
    /**
     * When using a `--stat=4096` or `--shortstat` options in the `git.log` or `git.stashList`,
     * each entry in the `ListLogSummary` will also have a `diff` property representing as much
@@ -175,4 +174,22 @@ export interface ListLogSummary<T = DefaultLogFields> {
    all: ReadonlyArray<T & ListLogLine>;
    total: number;
    latest: T & ListLogLine;
+}
+
+export interface MergeConflict {
+   /* Type of conflict */
+   reason: string;
+   /* Path to file */
+   file: string;
+   meta?: {
+      /* Where the file was deleted, if there is a modify/delete conflict */
+      deleteRef?: string;
+   };
+}
+
+export interface MergeSummary extends PullResult {
+   conflicts: MergeConflict[];
+   merges: string[];
+   result: "success" | string;
+   failed: boolean;
 }


### PR DESCRIPTION
Fixes #419 with the following changes:

* updated `git.status` should now report most types of merge conflicts, including modify/delete.
* updated `git.merge` to correctly parse the filename of modify/delete conflicts and also add a meta object containing information about where the file is deleted to distinguish between the file being deleted locally or remotely

Note that there are other conflicts that are not completely picked up by the parsers, they should report a conflict with a reason but not a file. The reason why I haven't implemented these is that there were quite a few different types of message structures and they all related to renames, which are hard to store in the existing conflicts data structure. I looked at https://github.com/git/git/blob/042ed3e048af08014487d19196984347e3be7d1c/merge-recursive.c and searched for `"CONFLICT ` to look at the different conflict messages.
