### PR TITLE
Only pass callback through from `addTag` to `tag` when present, to al…

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -485,7 +485,8 @@
          });
       }
 
-      return this.tag([name], then);
+      var command = [name];
+      return then ? this.tag(command, then) : this.tag(command);
    };
 
    /**

--- a/test/integration/test-tag.js
+++ b/test/integration/test-tag.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const Test = require('./include/runner');
+
+const setUp = (context) => {
+   const repo = context.gitP(context.root);
+
+   return repo.init()
+      .then(() => context.file('foo', 'bar', 'content'))
+      .then(() => repo.add('foo/*'))
+      .then(() => repo.commit('message'));
+};
+
+module.exports = {
+
+   'creates a named tag without the need for a callback': new Test(setUp, (context, assert) => {
+      const g = context.git(context.root);
+      g.addTag('newTag');
+
+      return new Promise(async (done) => {
+         setTimeout(() => {
+            context.gitP(context.root)
+               .tag()
+               .then(tags => {
+                  assert.same(String(tags).trim(), 'newTag');
+                  done()
+               })
+               .catch(e => {
+                  done(e);
+               });
+
+         }, 250);
+
+      });
+
+   }),
+
+};


### PR DESCRIPTION
…low for creating named tags without a callback.

Closes #423