### PR TITLE
Removes error when checkIsRepo reports a non-root

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1305,7 +1305,7 @@ To use promises switch to importing 'simple-git/promise'.`);
     */
    Git.prototype.checkIsRepo = function (then) {
       function onError (exitCode, stdErr, done, fail) {
-         if (exitCode === 128 && /(Not a git repository|Kein Git-Repository)/i.test(stdErr)) {
+         if (exitCode === 128) {
             return done(false);
          }
 


### PR DESCRIPTION
Remove error thrown by checkIsRepo when reporting a non-root. The function should simply return the value false but not create an error.
