### PR TITLE
Add support for patch information in DiffSummary

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   ],
   "dependencies": {
     "@kwsites/exec-p": "^0.4.0",
-    "debug": "^4.0.1"
+    "debug": "^4.0.1",
+    "diff2html": "^3.1.6"
   },
   "devDependencies": {
     "@kwsites/jestify-node-unit": "^1.0.1",

--- a/src/git.js
+++ b/src/git.js
@@ -1236,7 +1236,7 @@ Git.prototype.log = function (options, then) {
 
    return this._run(
       command.concat(suffix),
-      Git._responseHandler(handler, 'ListLogSummary', [splitter, fields])
+      Git._responseHandler(handler, 'ListLogSummary', [splitter, fields, command.includes("-p")])
    );
 };
 

--- a/src/responses/DiffSummary.js
+++ b/src/responses/DiffSummary.js
@@ -1,6 +1,8 @@
 
 module.exports = DiffSummary;
 
+var diff2html = require("diff2html");
+
 /**
  * The DiffSummary is returned as a response to getting `git().status()`
  *
@@ -11,6 +13,7 @@ function DiffSummary () {
    this.insertions = 0;
    this.deletions = 0;
    this.changed = 0;
+   this.patch = {};
 }
 
 /**
@@ -31,11 +34,17 @@ DiffSummary.prototype.deletions = 0;
  */
 DiffSummary.prototype.changed = 0;
 
-DiffSummary.parse = function (text) {
-   var line, handler;
+DiffSummary.parse = function (text, isPatch) {
+   var line;
+
+   var status = new DiffSummary();
+
+   if (isPatch) {
+      status.patch = diff2html.parse(text.trim());
+      return status;
+   }
 
    var lines = text.trim().split('\n');
-   var status = new DiffSummary();
 
    var summary = lines.pop();
    if (summary) {

--- a/src/responses/ListLogSummary.js
+++ b/src/responses/ListLogSummary.js
@@ -51,7 +51,7 @@ ListLogSummary.COMMIT_BOUNDARY = ' òò';
 
 ListLogSummary.SPLITTER = ' ò ';
 
-ListLogSummary.parse = function (text, splitter, fields) {
+ListLogSummary.parse = function (text, splitter, fields, isPatch) {
    fields = fields || ['hash', 'date', 'message', 'refs', 'author_name', 'author_email'];
    return new ListLogSummary(
       text
@@ -63,7 +63,7 @@ ListLogSummary.parse = function (text, splitter, fields) {
             var listLogLine = new ListLogLine(lineDetail[0].trim().split(splitter), fields);
 
             if (lineDetail.length > 1 && !!lineDetail[1].trim()) {
-               listLogLine.diff = DiffSummary.parse(lineDetail[1]);
+               listLogLine.diff = DiffSummary.parse(lineDetail[1], isPatch);
             }
 
             return listLogLine;


### PR DESCRIPTION
This pull request certainly requires changes before any potential merge, please let me know. It performs the following:

- Add dependency on diff2html
- Parse patch information when `log` is called with the patch switch (`-p`)

Related issue: #440 