### PR TITLE
Fix `.getRemotes` type

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -252,7 +252,7 @@ declare namespace simplegit {
        *
        * @param {boolean} [verbose=false]
        */
-      getRemotes(verbose: false | undefined): Promise<resp.RemoteWithoutRefs[]>;
+      getRemotes(verbose?: false): Promise<resp.RemoteWithoutRefs[]>;
 
       getRemotes(verbose: true): Promise<resp.RemoteWithRefs[]>;
 


### PR DESCRIPTION
According to docs, `verbose` is an optional argument, yet calling the function without this argument causes a TypeScript error.