### PR TITLE
BugFix: await git.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 <!-- Notes added below this line -->
 <!-- Template: ${version} -->
 
+## 2.7.1 - Bug Fix: `await git.log` having imported from root `simple-git`
+
+- Fixes #464, whereby using `await` on `git.log` without having supplied a callback would ignore the leading options
+  object or options array. 
+
 ## 2.7.0 - Output Handler and logging
 
 - Updated to the `outputHandler` type to add a trailing argument for the arguments passed into the child process.

--- a/src/git.js
+++ b/src/git.js
@@ -1027,7 +1027,7 @@ Git.prototype.catch = function (onError) {
  */
 Git.prototype.log = function (options, then) {
    var handler = Git.trailingFunctionArgument(arguments);
-   var opt = (handler === then ? options : null) || {};
+   var opt = Git.trailingOptionsArgument(arguments) || {};
 
    var splitter = opt.splitter || requireResponseHandler('ListLogSummary').SPLITTER;
    var format = opt.format || {

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -204,6 +204,20 @@ describe('log-2', () => {
       expect(theCommandRun().includes('--all')).toBe(true);
    });
 
+   it('when awaiting options object', async () => {
+      const from = 'from-name';
+      const to = 'to-name';
+
+      git.log({from, to, symmetric: true});
+      await closeWithSuccess();
+
+      expect(theCommandRun()).toEqual([
+         'log',
+         `--pretty=format:${ START_BOUNDARY }%H${ SPLITTER }%aI${ SPLITTER }%s${ SPLITTER }%D${ SPLITTER }%b${ SPLITTER }%aN${ SPLITTER }%ae${COMMIT_BOUNDARY}`,
+         `${from}...${to}`,
+      ]);
+   });
+
 });
 
 exports.log = {


### PR DESCRIPTION
Adds assertion for using a leading options object in `git.log`