### PR TITLE
Add support for use as an ES module with default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 <!-- Notes added below this line -->
 <!-- Template: ${version} -->
 
+## 2.8.0 - Support for `default` import in TS without use of `esModuleInterop`
+
+- Enables support for using the default export of `simple-git` as an es module, in TypeScript it is no
+  longer necessary to enable the `esModuleInterop` flag in the `tsconfig.json` to consume the default
+  export.
+
 ## 2.7.2 - Bug Fix: Remove `promise.ts` source from `simple-git` published artifact
 
 - Closes #471, whereby the source for the promise wrapped runner would be included in the published artifact

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "clean": "git clean -fxd -e .idea -e node_modules",
     "tsc": "tsc",
     "build": "tsc --build",
+    "build:clean": "yarn clean && yarn build",
     "pretest": "yarn build",
     "test": "tsc -p test/consumer/tsconfig.json && jest --coverage",
     "preversion": "yarn test",

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -13,38 +13,27 @@ declare namespace simplegit {
 
    type SimpleGit = simpleGit.SimpleGit;
 
-   type Options = types.Options;
-
-   type LogOptions<T = types.DefaultLogFields> = types.LogOptions<T>;
-
    // errors
    type GitError = errors.GitError;
    type GitResponseError<T> = errors.GitResponseError<T>;
    type TaskConfigurationError = errors.TaskConfigurationError;
 
    // responses
-   // ---------------------
-   type BranchSummary = types.BranchSummary
-
-   type CleanSummary = types.CleanSummary;
-
+   type BranchSummary = resp.BranchSummary
+   type CleanSummary = resp.CleanSummary;
    type CleanMode = types.CleanMode;
-
-   type CommitSummary = resp.CommitSummary;
-
-   type MergeSummary = resp.MergeSummary;
-
-   type PullResult = resp.PullResult;
-
-   type FetchResult = resp.FetchResult;
-
-   type StatusResult = resp.StatusResult;
-
    type DiffResult = resp.DiffResult;
-
+   type FetchResult = resp.FetchResult;
+   type CommitSummary = resp.CommitSummary;
+   type MergeSummary = resp.MergeSummary;
+   type PullResult = resp.PullResult;
+   type StatusResult = resp.StatusResult;
    type TagResult = resp.TagResult;
 
+   // types
    type outputHandler = types.outputHandler
+   type LogOptions<T = types.DefaultLogFields> = types.LogOptions<T>;
+   type Options = types.Options;
 
 }
 

--- a/src/git-factory.js
+++ b/src/git-factory.js
@@ -9,6 +9,19 @@ for (let imported = require('./lib/api'), keys = Object.keys(imported), i = 0; i
    }
 }
 
+/**
+ * Adds the necessary properties to the supplied object to enable it for use as
+ * the default export of a module.
+ *
+ * Eg: `module.exports = esModuleFactory({ something () {} })`
+ */
+module.exports.esModuleFactory = function esModuleFactory(defaultExport) {
+   return Object.defineProperties(defaultExport, {
+      __esModule: { value: true },
+      default: { value: defaultExport },
+   });
+}
+
 module.exports.gitExportFactory = function gitExportFactory (factory, extra) {
    return Object.assign(function () {
          return factory.apply(null, arguments);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 
 const {gitP} = require('./lib/runners/promise-wrapped');
-const {gitInstanceFactory, gitExportFactory} = require('./git-factory');
+const {esModuleFactory, gitInstanceFactory, gitExportFactory} = require('./git-factory');
 
-module.exports = gitExportFactory(gitInstanceFactory, {gitP});
+module.exports = esModuleFactory(
+   gitExportFactory(gitInstanceFactory, {gitP})
+);

--- a/src/lib/responses/BranchDeleteSummary.ts
+++ b/src/lib/responses/BranchDeleteSummary.ts
@@ -1,38 +1,5 @@
+import { BranchDeletionBatchSummary, BranchDeletionSummary } from '../../../typings';
 import { ExitCodes } from '../utils';
-
-/**
- * Represents the status of a single branch deletion
- */
-export interface BranchDeletionSummary {
-   branch: string;
-   hash: string | null;
-   readonly success: boolean;
-}
-
-/**
- * Represents the status of having deleted a batch of branches
- */
-export interface BranchDeletionBatchSummary {
-   /**
-    * All branches included in the response
-    */
-   all: BranchDeletionSummary[];
-
-   /**
-    * Branches mapped by their branch name
-    */
-   branches: { [branchName: string]: BranchDeletionSummary };
-
-   /**
-    * Array of responses that are in error
-    */
-   errors: BranchDeletionSummary[];
-
-   /**
-    * Flag showing whether all branches were deleted successfully
-    */
-   readonly success: boolean;
-}
 
 export class BranchDeletionBatch implements BranchDeletionBatchSummary {
    all: BranchDeletionSummary[] = [];

--- a/src/lib/responses/BranchSummary.ts
+++ b/src/lib/responses/BranchSummary.ts
@@ -1,18 +1,4 @@
-export interface BranchSummaryBranch {
-   current: boolean;
-   name: string;
-   commit: string;
-   label: string;
-}
-
-export interface BranchSummary {
-   detached: boolean;
-   current: string;
-   all: string[];
-   branches: {
-      [key: string]: BranchSummaryBranch;
-   };
-}
+import { BranchSummary, BranchSummaryBranch } from '../../../typings';
 
 export class BranchSummaryResult implements BranchSummary {
    public all: string[] = [];

--- a/src/lib/responses/CleanSummary.ts
+++ b/src/lib/responses/CleanSummary.ts
@@ -1,11 +1,5 @@
+import { CleanSummary } from '../../../typings';
 import { toLinesWithContent } from '../utils';
-
-export interface CleanSummary {
-   readonly dryRun: boolean;
-   paths: string[];
-   files: string[];
-   folders: string[];
-}
 
 export class CleanResponse implements CleanSummary {
 
@@ -27,7 +21,7 @@ export function cleanSummaryParser (dryRun: boolean, text: string): CleanSummary
    const summary = new CleanResponse(dryRun);
    const regexp = dryRun ? dryRunRemovalRegexp : removalRegexp;
 
-   toLinesWithContent(text, true).forEach(line => {
+   toLinesWithContent(text).forEach(line => {
       const removed = line.replace(regexp, '');
 
       summary.paths.push(removed);

--- a/src/lib/responses/ConfigList.ts
+++ b/src/lib/responses/ConfigList.ts
@@ -1,34 +1,5 @@
-import { last, splitOn } from '../utils/util';
-
-/**
- * Represents the map of configuration settings
- */
-export interface ConfigValues {
-   [key: string]: string | string[];
-}
-
-/**
- * Represents the current git configuration, as defined by the output from `git log`
- */
-export interface ConfigListSummary {
-
-   /**
-    * All configuration settings, where local/user settings override user/global settings
-    * the overridden value will appear in this object.
-    */
-   readonly all: ConfigValues;
-
-   /**
-    * The file paths configuration was read from
-    */
-   files: string[];
-
-   /**
-    * The `ConfigValues` for each of the `files`, use this object to determine
-    * local repo, user and global settings.
-    */
-   values: {[fileName: string]: ConfigValues};
-}
+import { ConfigListSummary, ConfigValues } from '../../../typings';
+import { last, splitOn } from '../utils';
 
 export class ConfigList implements ConfigListSummary {
 

--- a/src/lib/responses/GetRemoteSummary.ts
+++ b/src/lib/responses/GetRemoteSummary.ts
@@ -1,3 +1,4 @@
+import { forEachLineWithContent } from '../utils';
 
 export interface RemoteWithoutRefs {
    name: string;
@@ -38,14 +39,5 @@ export function parseGetRemotesVerbose (text: string): RemoteWithRefs[] {
 }
 
 function forEach(text: string, handler: (line: string[]) => void) {
-   text.split('\n').forEach(line => {
-      const row = line.trim();
-      if (!row) {
-         return;
-      }
-
-      if (row) {
-         handler(row.split(/\s+/));
-      }
-   });
+   forEachLineWithContent(text, (line) => handler(line.split(/\s+/)));
 }

--- a/src/lib/tasks/branch.ts
+++ b/src/lib/tasks/branch.ts
@@ -1,12 +1,8 @@
+import { BranchDeletionBatchSummary, BranchDeletionSummary, BranchSummary } from '../../../typings';
 import { StringTask } from './task';
 import { GitResponseError } from '../errors/git-response-error';
-import { BranchSummary, parseBranchSummary } from '../responses/BranchSummary';
-import {
-   BranchDeletionBatchSummary,
-   BranchDeletionSummary,
-   hasBranchDeletionError,
-   parseBranchDeletions
-} from '../responses/BranchDeleteSummary';
+import { parseBranchSummary } from '../responses/BranchSummary';
+import { hasBranchDeletionError, parseBranchDeletions } from '../responses/BranchDeleteSummary';
 
 export function containsDeleteBranchCommand(commands: string[]) {
    const deleteCommands = ['-d', '-D', '--delete'];

--- a/src/lib/tasks/clean.ts
+++ b/src/lib/tasks/clean.ts
@@ -1,6 +1,7 @@
+import { CleanSummary } from '../../../typings';
 import { configurationErrorTask, StringTask } from './task';
 import { Maybe } from '../utils';
-import { CleanSummary, cleanSummaryParser } from '../responses/CleanSummary';
+import { cleanSummaryParser } from '../responses/CleanSummary';
 
 export const CONFIG_ERROR_INTERACTIVE_MODE = 'Git clean interactive mode is not supported';
 export const CONFIG_ERROR_MODE_REQUIRED = 'Git clean mode parameter ("n" or "f") is required';

--- a/src/lib/tasks/config.ts
+++ b/src/lib/tasks/config.ts
@@ -1,5 +1,6 @@
+import { ConfigListSummary } from '../../../typings';
 import { StringTask } from './task';
-import { configListParser, ConfigListSummary } from '../responses/ConfigList';
+import { configListParser } from '../responses/ConfigList';
 
 export function addConfigTask (key: string, value: string, append = false): StringTask<string> {
    const commands: string[] = ['config', '--local'];

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -35,7 +35,7 @@ export function last<T>(input: T[]): T | undefined {
    return input && input.length ? input[input.length - 1] : undefined;
 }
 
-export function toLinesWithContent(input: string, trimmed = false): string[] {
+export function toLinesWithContent(input: string, trimmed = true): string[] {
    return input.split('\n')
       .reduce((output, line) => {
          const lineContent = trimmed ? line.trim() : line;
@@ -46,13 +46,25 @@ export function toLinesWithContent(input: string, trimmed = false): string[] {
       }, [] as string[]);
 }
 
+type LineWithContentCallback<T = void> = (line: string) => T;
+type LineWithContentTrailingArgs<T> = [LineWithContentCallback<T>] | [boolean, LineWithContentCallback<T>];
+export function forEachLineWithContent<T>(input: string, ...opt: LineWithContentTrailingArgs<T>): T[] {
+   const [trimmed, callback] = opt.length === 1 ? [undefined, opt[0]] : opt;
+   return toLinesWithContent(input, trimmed).map(line => callback(line));
+}
+
 export function folderExists(path: string): boolean {
    return exists(path, FOLDER);
 }
 
+/**
+ * Adds `item` into the `target` `Array` or `Set` when it is not already present.
+ */
 export function append<T>(target: T[] | Set<T>, item: T): typeof item {
    if (Array.isArray(target)) {
-      target.push(item);
+      if (!target.includes(item)) {
+         target.push(item);
+      }
    }
    else {
       target.add(item);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,4 +1,3 @@
-import { NOOP } from "../src/lib/utils";
 
 module.exports.autoMergeFile = (fileName = 'pass.txt') => {
    return `
@@ -157,4 +156,21 @@ module.exports.mockDebugModule = (function mockDebugModule () {
 
    return debug;
 
+}());
+
+module.exports.mockFileExistsModule = (function mockFileExistsModule () {
+   let next = true;
+
+   return {
+      $fails () {
+         next = false;
+      },
+      $reset () {
+         next = true;
+      },
+      exists () {
+         return next;
+      },
+      FOLDER: 2,
+   };
 }());

--- a/test/unit/git.spec.js
+++ b/test/unit/git.spec.js
@@ -59,6 +59,13 @@ describe('git', () => {
 
       afterEach(() => $reset());
 
+      it('can be created using the default export', () => {
+         expect(simpleGit.__esModule).toBe(true);
+         expect(simpleGit.default).toEqual(simpleGit);
+
+         expect(() => simpleGit.default()).not.toThrow();
+      });
+
       it('throws when created with a non-existent directory', () => {
          $fails();
          expect(() => simpleGit('/tmp/foo-bar-baz')).toThrow();

--- a/test/unit/include/setup.js
+++ b/test/unit/include/setup.js
@@ -1,7 +1,11 @@
 (function () {
    'use strict';
 
-   const { mockDebugModule } = require('../../helpers');
+   const { mockDebugModule, mockFileExistsModule } = require('../../helpers');
+   const onRestore = [
+      mockDebugModule.$reset,
+      mockFileExistsModule.$reset,
+   ];
 
    jest.mock('child_process', () => {
       return new MockChildProcess(true);
@@ -9,22 +13,7 @@
 
    jest.mock('debug', () => mockDebugModule);
 
-   jest.mock('@kwsites/file-exists', () => {
-      let next = true;
-
-      return {
-         $fails () {
-            next = false;
-         },
-         $reset () {
-            next = true;
-         },
-         exists () {
-            return next;
-         },
-         FOLDER: 2,
-      };
-   });
+   jest.mock('@kwsites/file-exists', () => mockFileExistsModule);
 
    var mockChildProcess, mockChildProcesses = [], git;
    var sinon = require('sinon');
@@ -189,7 +178,7 @@
             sandbox.restore();
          }
 
-         tryCalling(require('debug').$reset);
+         onRestore.forEach(tryCalling);
       },
 
       wait,

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -1,13 +1,59 @@
 import {
+   append,
    filterArray,
    filterFunction,
    filterHasLength,
    filterPlainObject,
-   filterPrimitives,
-   NOOP
+   filterPrimitives, forEachLineWithContent,
+   NOOP, toLinesWithContent
 } from "../../src/lib/utils";
 
 describe('utils', () => {
+
+   describe('content', () => {
+
+      it('filters lines with content', () => {
+         expect(toLinesWithContent(' \n content \n\n')).toEqual(['content']);
+         expect(toLinesWithContent(' \n content \n\n', false)).toEqual([' ', ' content ']);
+      });
+
+      it('maps lines with content', () => {
+         expect(forEachLineWithContent(' \n content \n\n', (line) => line.toUpperCase()))
+            .toEqual(['CONTENT']);
+         expect(forEachLineWithContent(' \n content \n\n', true, (line) => line.toUpperCase()))
+            .toEqual(['CONTENT']);
+         expect(forEachLineWithContent(' \n content \n\n', false, (line) => line.toUpperCase()))
+            .toEqual([' ', ' CONTENT ']);
+      });
+
+   });
+
+   describe('arrays', () => {
+
+      function test (target, itemA, itemB) {
+         expect(append(target, itemA)).toBe(itemA);
+         expect(Array.from(target)).toEqual([itemA]);
+
+         expect(append(target, itemB)).toBe(itemB);
+         expect(Array.from(target)).toEqual([itemA, itemB]);
+
+         expect(append(target, itemA)).toBe(itemA);
+         expect(Array.from(target)).toEqual([itemA, itemB]);
+      }
+
+      it('appends objects into an array', () => {
+         test([], {a: 1}, {b: 1});
+      });
+      it('appends primitives into an array', () => {
+         test([], 'A', 'B');
+      });
+      it('appends objects into a set', () => {
+         test(new Set(), {a: 1}, {b: 1});
+      });
+      it('appends primitives into a set', () => {
+         test(new Set(), 'A', 'B');
+      });
+   });
 
    describe('argument filtering', () => {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,7 @@
   "exclude": [
     // TODO if using an outDir under the rootDir, exclude that here too
     "node_modules",
-    "test",
-    "test-consumer"
+    "test"
   ],
 //  "files": [],
   "include": [

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,8 +1,8 @@
 import { SimpleGit } from './simple-git';
 
+export { SimpleGit };
 export * from './errors';
 export * from './response';
-export * from './simple-git';
 export * from './types';
 
 export declare function gitP(basePath?: string): SimpleGit;

--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -1,5 +1,62 @@
 import { DefaultLogFields } from '../src/lib/tasks/log';
 
+export interface BranchSummaryBranch {
+   current: boolean;
+   name: string;
+   commit: string;
+   label: string;
+}
+
+export interface BranchSummary {
+   detached: boolean;
+   current: string;
+   all: string[];
+   branches: {
+      [key: string]: BranchSummaryBranch;
+   };
+}
+
+/**
+ * Represents the status of a single branch deletion
+ */
+export interface BranchDeletionSummary {
+   branch: string;
+   hash: string | null;
+   readonly success: boolean;
+}
+
+/**
+ * Represents the status of having deleted a batch of branches
+ */
+export interface BranchDeletionBatchSummary {
+   /**
+    * All branches included in the response
+    */
+   all: BranchDeletionSummary[];
+
+   /**
+    * Branches mapped by their branch name
+    */
+   branches: { [branchName: string]: BranchDeletionSummary };
+
+   /**
+    * Array of responses that are in error
+    */
+   errors: BranchDeletionSummary[];
+
+   /**
+    * Flag showing whether all branches were deleted successfully
+    */
+   readonly success: boolean;
+}
+
+export interface CleanSummary {
+   readonly dryRun: boolean;
+   paths: string[];
+   files: string[];
+   folders: string[];
+}
+
 export interface CommitSummary {
    author: null | {
       email: string;
@@ -12,6 +69,36 @@ export interface CommitSummary {
       insertions: number;
       deletions: number;
    };
+}
+
+/**
+ * Represents the current git configuration, as defined by the output from `git log`
+ */
+export interface ConfigListSummary {
+
+   /**
+    * All configuration settings, where local/user settings override user/global settings
+    * the overridden value will appear in this object.
+    */
+   readonly all: ConfigValues;
+
+   /**
+    * The file paths configuration was read from
+    */
+   files: string[];
+
+   /**
+    * The `ConfigValues` for each of the `files`, use this object to determine
+    * local repo, user and global settings.
+    */
+   values: {[fileName: string]: ConfigValues};
+}
+
+/**
+ * Represents the map of configuration settings
+ */
+export interface ConfigValues {
+   [key: string]: string | string[];
 }
 
 export interface DiffResultTextFile {

--- a/typings/simple-git.d.ts
+++ b/typings/simple-git.d.ts
@@ -33,7 +33,7 @@ export interface SimpleGit {
    /**
     * Configuration values visible to git in the current working directory
     */
-   listConfig(): Promise<types.ConfigListSummary>;
+   listConfig(): Promise<resp.ConfigListSummary>;
 
    /**
     * Adds a remote to the list of remotes.
@@ -62,15 +62,13 @@ export interface SimpleGit {
    /**
     * List all branches
     */
-   branch(): Promise<types.BranchSummary>;
-   branch(options: Options | string[]): Promise<types.BranchSummary>;
+   branch(): Promise<resp.BranchSummary>;
+   branch(options: Options | string[]): Promise<resp.BranchSummary>;
 
    /**
     * List of local branches
-    *
-    * @returns {Promise<types.BranchSummary>}
     */
-   branchLocal(): Promise<types.BranchSummary>;
+   branchLocal(): Promise<resp.BranchSummary>;
 
    /**
     * Returns a list of objects in a tree based on commit hash.
@@ -146,8 +144,8 @@ export interface SimpleGit {
     await git.clean(CleanOptions.IGNORED + CleanOptions.FORCE, {'./path': null});
     * ```
     */
-   clean(args: types.CleanOptions[], options?: Options | string[]): Promise<types.CleanSummary>;
-   clean(mode: types.CleanMode | string, options?: Options | string[]): Promise<types.CleanSummary>;
+   clean(args: types.CleanOptions[], options?: Options | string[]): Promise<resp.CleanSummary>;
+   clean(mode: types.CleanMode | string, options?: Options | string[]): Promise<resp.CleanSummary>;
 
    /**
     * Clears the queue of pending commands and returns the wrapper instance for chaining.
@@ -201,7 +199,7 @@ export interface SimpleGit {
     * @param {string} branchName name of branch
     * @param {boolean} [forceDelete=false] set to true to forcibly delete unmerged branches
     */
-   deleteLocalBranch(branchName: string, forceDelete?: boolean): Promise<types.BranchDeletionSummary>;
+   deleteLocalBranch(branchName: string, forceDelete?: boolean): Promise<resp.BranchDeletionSummary>;
 
    /**
     * Delete one or more local branches. Supply the branchName as a string to return a
@@ -211,7 +209,7 @@ export interface SimpleGit {
     * @param {string[]} branchNames name of branch or array of branch names
     * @param {boolean} [forceDelete=false] set to true to forcibly delete unmerged branches
     */
-   deleteLocalBranches(branchNames: string[], forceDelete?: boolean): Promise<types.BranchDeletionSummary[]>;
+   deleteLocalBranches(branchNames: string[], forceDelete?: boolean): Promise<resp.BranchDeletionSummary[]>;
 
    /**
     * Get the diff of the current repo compared to the last commit with a set of options supplied as a string.

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -1,8 +1,4 @@
 
-export { BranchDeletionBatchSummary, BranchDeletionSummary } from '../src/lib/responses/BranchDeleteSummary';
-export { BranchSummary, BranchSummaryBranch } from '../src/lib/responses/BranchSummary';
-export { CleanSummary } from '../src/lib/responses/CleanSummary';
-export { ConfigListSummary, ConfigValues } from '../src/lib/responses/ConfigList';
 export { RemoteWithoutRefs, RemoteWithRefs } from '../src/lib/responses/GetRemoteSummary';
 export { LogOptions, DefaultLogFields } from '../src/lib/tasks/log';
 


### PR DESCRIPTION
As noted in #473, the default export for `simple-git` would fail when imported without having `esModuleInterop` enabled in the `tsconfig.json`.

```typescript
import simpleGit, { SimpleGit } from 'simple-git';

expect(() => simpleGit()).not.toThrow();
```