### PR TITLE
Feature: PushResult should contain all remote messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Change History & Release Notes
 
+## 2.13.2 - PushResult to expose all non-empty remote messages
+
+- Further to `2.13.0` includes all (non-empty) `remote:` lines in the `PushResult`,
+  including `remote:` lines used for other parser results (ie: `pullRequestUrl` etc).
+
 ## 2.13.1 - Add support for parsing GitLab Pull Request Url Message
 
 - Further to `2.13.0` adding support for parsing the reponse to `git.push`, adds support for the pull request message

--- a/src/lib/responses/PushSummary.ts
+++ b/src/lib/responses/PushSummary.ts
@@ -59,28 +59,32 @@ const parsers: LineParser<PushResult>[] = [
          },
       };
    }),
+   new LineParser(/^remote:\s*(.+)$/, (result, [text]) => {
+      const message = text.trim();
+      if (message) {
+         result.remoteMessages.all.push(message);
+      }
+      return false;
+   }),
    new RemoteLineParser([/create a (?:pull|merge) request/i, /\s(https?:\/\/\S+)$/], (result, [pullRequestUrl]) => {
-      result.remoteMessages = {
-         ...(result.remoteMessages || {}),
-         pullRequestUrl,
-      };
+      result.remoteMessages.pullRequestUrl = pullRequestUrl;
    }),
    new RemoteLineParser([/found (\d+) vulnerabilities.+\(([^)]+)\)/i, /\s(https?:\/\/\S+)$/], (result, [count, summary, url]) => {
-      result.remoteMessages = {
-         ...(result.remoteMessages || {}),
-         vulnerabilities: {
-            count: asNumber(count),
-            summary,
-            url,
-         },
+      result.remoteMessages.vulnerabilities = {
+         count: asNumber(count),
+         summary,
+         url,
       };
-   })
+   }),
 ];
 
 
 export function parsePush(text: string): PushResult {
    const summary: PushResult = {
       pushed: [],
+      remoteMessages: {
+         all: [],
+      },
    };
    parseLinesWithContent(summary, parsers, text);
    return summary;

--- a/src/lib/utils/line-parser.ts
+++ b/src/lib/utils/line-parser.ts
@@ -2,25 +2,14 @@ import { toLinesWithContent } from './util';
 
 export function parseLinesWithContent<T>(result: T, parsers: LineParser<T>[], text: string) {
    for (let lines = toLinesWithContent(text), i = 0, max = lines.length; i < max; i++) {
-      let usedOffset = 0;
       const line = (offset = 0) => {
          if ((i + offset) >= max) {
             return;
          }
-
-         usedOffset = Math.max(usedOffset, offset);
          return lines[i + offset];
       }
 
-      parsers.some(({parse}) => {
-         usedOffset = 0;
-         const parsedLine = parse(line, result);
-         if (parsedLine) {
-            i+= usedOffset;
-         }
-
-         return parsedLine;
-      });
+      parsers.some(({parse}) => parse(line, result));
    }
 
    return result;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,6 +7,7 @@ Object.assign(module.exports, {
    autoMergeResponse,
    createSingleConflict,
    createTestContext,
+   like,
    mockChildProcessModule: mockChildProcessModule(),
    promiseError,
    promiseResult,
@@ -17,6 +18,10 @@ Object.assign(module.exports, {
    setUpInit,
    wait,
 });
+
+function like (what) {
+   return expect.objectContaining(what);
+}
 
 function autoMergeFile (fileName = 'pass.txt') {
    return `

--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -341,6 +341,7 @@ export interface PushResultPushedItem {
 }
 
 export interface PushResultRemoteResponseMessages {
+   all: string[];
    pullRequestUrl?: string;
    vulnerabilities?: {
       count: number;
@@ -371,6 +372,6 @@ export interface PushResult {
       remote: string;
       remoteName: string;
    };
-   remoteMessages?: PushResultRemoteResponseMessages;
+   remoteMessages: PushResultRemoteResponseMessages;
    update?: PushResultBranchUpdate;
 }


### PR DESCRIPTION
Include all `remote:` messages in the `PushResult` which would allow consumers of `simple-git` to apply their own custom parsing of the responses.