### PR TITLE
Feature: Pull remote messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Change History & Release Notes
 
+## 2.17.0 - Add remote message parsing to `git pull`
+
+- `git pull` (and by extension `git merge`) adds remote message parsing to the `PullResult` type
+- Remote message parsing adds property `remoteMessages.objects` of type `RemoteMessagesObjectEnumeration` to capture the  objects transferred in fetch and push.
+
 ## 2.16.0 - Upgrade Move task
 
 - `git.mv` rewritten to fit the TypeScript tasks style.

--- a/src/lib/parsers/parse-merge.ts
+++ b/src/lib/parsers/parse-merge.ts
@@ -1,8 +1,8 @@
 import { MergeDetail, MergeResult } from '../../../typings';
-import { LineParser, parseStringResponse } from '../utils';
-import { TaskParser } from '../tasks/task';
-import { parsePullResult } from '../responses/PullSummary';
 import { MergeSummaryConflict, MergeSummaryDetail } from '../responses/MergeSummary';
+import { TaskParser } from '../tasks/task';
+import { LineParser, parseStringResponse } from '../utils';
+import { parsePullResult } from './parse-pull';
 
 const parsers: LineParser<MergeDetail>[] = [
    new LineParser(/^Auto-merging\s+(.+)$/, (summary, [autoMerge]) => {

--- a/src/lib/parsers/parse-pull.ts
+++ b/src/lib/parsers/parse-pull.ts
@@ -1,0 +1,48 @@
+import { PullDetail, PullResult, RemoteMessages } from '../../../typings';
+import { PullSummary } from '../responses/PullSummary';
+import { TaskParser } from '../tasks/task';
+import { append, LineParser, parseStringResponse } from '../utils';
+import { parseRemoteMessages } from './parse-remote-messages';
+
+const FILE_UPDATE_REGEX = /^\s*(.+?)\s+\|\s+\d+\s*(\+*)(-*)/;
+const SUMMARY_REGEX = /(\d+)\D+((\d+)\D+\(\+\))?(\D+(\d+)\D+\(-\))?/;
+const ACTION_REGEX = /^(create|delete) mode \d+ (.+)/;
+
+const parsers: LineParser<PullResult>[] = [
+   new LineParser(FILE_UPDATE_REGEX, (result, [file, insertions, deletions]) => {
+      result.files.push(file);
+
+      if (insertions) {
+         result.insertions[file] = insertions.length;
+      }
+
+      if (deletions) {
+         result.deletions[file] = deletions.length;
+      }
+   }),
+   new LineParser(SUMMARY_REGEX, (result, [changes, , insertions, , deletions]) => {
+      if (insertions !== undefined || deletions !== undefined) {
+         result.summary.changes = +changes || 0;
+         result.summary.insertions = +insertions || 0;
+         result.summary.deletions = +deletions || 0;
+         return true;
+      }
+      return false;
+   }),
+   new LineParser(ACTION_REGEX, (result, [action, file]) => {
+      append(result.files, file);
+      append((action === 'create') ? result.created : result.deleted, file);
+   }),
+];
+
+export const parsePullDetail: TaskParser<string, PullDetail> = (stdOut, stdErr) => {
+   return parseStringResponse(new PullSummary(), parsers, `${stdOut}\n${stdErr}`);
+}
+
+export const parsePullResult: TaskParser<string, PullResult> = (stdOut, stdErr) => {
+   return Object.assign(
+      new PullSummary(),
+      parsePullDetail(stdOut, stdErr),
+      parseRemoteMessages<RemoteMessages>(stdOut, stdErr),
+   );
+}

--- a/src/lib/parsers/parse-remote-objects.ts
+++ b/src/lib/parsers/parse-remote-objects.ts
@@ -1,0 +1,44 @@
+import { RemoteMessageResult, RemoteMessages, RemoteMessagesObjectEnumeration } from '../../../typings';
+import { asNumber, RemoteLineParser } from '../utils';
+
+function objectEnumerationResult<T extends RemoteMessages = RemoteMessages>(remoteMessages: T): RemoteMessagesObjectEnumeration {
+   return (remoteMessages.objects = remoteMessages.objects || {
+      compressing: 0,
+      counting: 0,
+      enumerating: 0,
+      packReused: 0,
+      reused: {count: 0, delta: 0},
+      total: {count: 0, delta: 0}
+   });
+}
+
+function asObjectCount(source: string) {
+   const count = /^\s*(\d+)/.exec(source);
+   const delta = /delta (\d+)/i.exec(source);
+
+   return {
+      count: asNumber(count && count[1] || '0'),
+      delta: asNumber(delta && delta[1] || '0'),
+   };
+}
+
+export const remoteMessagesObjectParsers: RemoteLineParser<RemoteMessageResult<RemoteMessages>>[] = [
+   new RemoteLineParser(/^remote:\s*(enumerating|counting|compressing) objects: (\d+),/i, (result, [action, count]) => {
+      const key = action.toLowerCase();
+      const enumeration = objectEnumerationResult(result.remoteMessages);
+
+      Object.assign(enumeration, {[key]: asNumber(count)});
+   }),
+   new RemoteLineParser(/^remote:\s*(enumerating|counting|compressing) objects: \d+% \(\d+\/(\d+)\),/i, (result, [action, count]) => {
+      const key = action.toLowerCase();
+      const enumeration = objectEnumerationResult(result.remoteMessages);
+
+      Object.assign(enumeration, {[key]: asNumber(count)});
+   }),
+   new RemoteLineParser(/total ([^,]+), reused ([^,]+), pack-reused (\d+)/i, (result, [total, reused, packReused]) => {
+      const objects = objectEnumerationResult(result.remoteMessages);
+      objects.total = asObjectCount(total);
+      objects.reused = asObjectCount(reused);
+      objects.packReused = asNumber(packReused);
+   }),
+];

--- a/src/lib/responses/ConfigList.ts
+++ b/src/lib/responses/ConfigList.ts
@@ -3,23 +3,22 @@ import { last, splitOn } from '../utils';
 
 export class ConfigList implements ConfigListSummary {
 
+   public files: string[] = [];
+   public values: { [fileName: string]: ConfigValues } = Object.create(null);
+
    private _all: ConfigValues | undefined;
 
-   public get all (): ConfigValues {
+   public get all(): ConfigValues {
       if (!this._all) {
-         this._all = Object.assign({},
-            ...this.files.map(file => this.values[file])
-         );
+         this._all = this.files.reduce((all: ConfigValues, file: string) => {
+            return Object.assign(all, this.values[file]);
+         }, {});
       }
 
-      return this._all as ConfigValues;
+      return this._all;
    }
 
-   public files: string[] = [];
-
-   public values: {[fileName: string]: ConfigValues} = Object.create(null);
-
-   public addFile (file: string): ConfigValues {
+   public addFile(file: string): ConfigValues {
       if (!(file in this.values)) {
          const latest = last(this.files);
          this.values[file] = latest ? Object.create(this.values[latest]) : {}
@@ -30,16 +29,14 @@ export class ConfigList implements ConfigListSummary {
       return this.values[file];
    }
 
-   public addValue (file: string, key: string, value: string) {
+   public addValue(file: string, key: string, value: string) {
       const values = this.addFile(file);
 
       if (!values.hasOwnProperty(key)) {
          values[key] = value;
-      }
-      else if (Array.isArray(values[key])) {
+      } else if (Array.isArray(values[key])) {
          (values[key] as string[]).push(value);
-      }
-      else {
+      } else {
          values[key] = [values[key] as string, value];
       }
 
@@ -48,7 +45,7 @@ export class ConfigList implements ConfigListSummary {
 
 }
 
-export function configListParser (text: string): ConfigList {
+export function configListParser(text: string): ConfigList {
    const config = new ConfigList();
    const lines = text.split('\0');
 
@@ -62,6 +59,6 @@ export function configListParser (text: string): ConfigList {
    return config;
 }
 
-function configFilePath (filePath: string): string {
+function configFilePath(filePath: string): string {
    return filePath.replace(/^(file):/, '');
 }

--- a/src/lib/responses/PullSummary.ts
+++ b/src/lib/responses/PullSummary.ts
@@ -1,9 +1,10 @@
 import { PullDetailFileChanges, PullDetailSummary, PullResult } from '../../../typings';
-import { append, LineParser, parseStringResponse } from '../utils';
-import { TaskParser } from '../tasks/task';
 
 export class PullSummary implements PullResult {
-   public created: string[] = [];
+   public remoteMessages = {
+      all: [],
+   };
+   public created = [];
    public deleted: string[] = [];
    public files: string[] = [];
    public deletions: PullDetailFileChanges = {};
@@ -15,37 +16,4 @@ export class PullSummary implements PullResult {
    };
 }
 
-const FILE_UPDATE_REGEX = /^\s*(.+?)\s+\|\s+\d+\s*(\+*)(-*)/;
-const SUMMARY_REGEX = /(\d+)\D+((\d+)\D+\(\+\))?(\D+(\d+)\D+\(-\))?/;
-const ACTION_REGEX = /^(create|delete) mode \d+ (.+)/;
 
-const parsers: LineParser<PullResult>[] = [
-   new LineParser(FILE_UPDATE_REGEX, (result, [file, insertions, deletions]) => {
-      result.files.push(file);
-
-      if (insertions) {
-         result.insertions[file] = insertions.length;
-      }
-
-      if (deletions) {
-         result.deletions[file] = deletions.length;
-      }
-   }),
-   new LineParser(SUMMARY_REGEX, (result, [changes, , insertions, , deletions]) => {
-      if (insertions !== undefined || deletions !== undefined) {
-         result.summary.changes = +changes || 0;
-         result.summary.insertions = +insertions || 0;
-         result.summary.deletions = +deletions || 0;
-         return true;
-      }
-      return false;
-   }),
-   new LineParser(ACTION_REGEX, (result, [action, file]) => {
-      append(result.files, file);
-      append((action === 'create') ? result.created : result.deleted, file);
-   }),
-];
-
-export const parsePullResult: TaskParser<string, PullResult> = (stdOut, stdErr) => {
-   return parseStringResponse(new PullSummary(), parsers, `${stdOut}\n${stdErr}`);
-}

--- a/src/lib/tasks/pull.ts
+++ b/src/lib/tasks/pull.ts
@@ -1,7 +1,7 @@
 import { PullResult } from '../../../typings';
 import { StringTask } from './task';
-import { parsePullResult } from '../responses/PullSummary';
 import { Maybe } from '../types';
+import { parsePullResult } from '../parsers/parse-pull';
 
 export function pullTask(remote: Maybe<string>, branch: Maybe<string>, customArgs: string[]): StringTask<PullResult> {
    const commands: string[] = ['pull', ...customArgs];

--- a/src/lib/utils/line-parser.ts
+++ b/src/lib/utils/line-parser.ts
@@ -1,7 +1,8 @@
 export class LineParser<T> {
-   private _regExp: RegExp[];
 
    protected matches: string[] = [];
+
+   private _regExp: RegExp[];
 
    constructor(
       regExp: RegExp | RegExp[],
@@ -13,11 +14,6 @@ export class LineParser<T> {
       }
    }
 
-   // @ts-ignore
-   protected useMatches(target: T, match: string[]): boolean | void {
-      throw new Error(`LineParser:useMatches not implemented`);
-   }
-
    parse = (line: (offset: number) => (string | undefined), target: T): boolean => {
       this.resetMatches();
 
@@ -26,6 +22,11 @@ export class LineParser<T> {
       }
 
       return this.useMatches(target, this.prepareMatches()) !== false;
+   }
+
+   // @ts-ignore
+   protected useMatches(target: T, match: string[]): boolean | void {
+      throw new Error(`LineParser:useMatches not implemented`);
    }
 
    protected resetMatches() {
@@ -47,6 +48,20 @@ export class LineParser<T> {
 
    protected pushMatch(_index: number, matched: string[]) {
       this.matches.push(...matched.slice(1));
+   }
+
+}
+
+export class RemoteLineParser<T> extends LineParser<T> {
+
+   protected addMatch(reg: RegExp, index: number, line?: string): boolean {
+      return /^remote:\s/.test(String(line)) && super.addMatch(reg, index, line);
+   }
+
+   protected pushMatch(index: number, matched: string[]) {
+      if (index > 0 || matched.length > 1) {
+         super.pushMatch(index, matched);
+      }
    }
 
 }

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -92,7 +92,11 @@ export function asStringArray<T>(source: T | T[]): string[] {
    return asArray(source).map(String);
 }
 
-export function asNumber(source: string, onNaN = 0) {
+export function asNumber(source: string | null | undefined, onNaN = 0) {
+   if (source == null) {
+      return onNaN;
+   }
+
    const num = parseInt(source, 10);
    return isNaN(num) ? onNaN : num;
 }

--- a/test/unit/__fixtures__/index.js
+++ b/test/unit/__fixtures__/index.js
@@ -1,7 +1,7 @@
 
-module.exports = ['push'].reduce((all, dir) => {
+module.exports = ['push', 'remote-messages'].reduce((all, dir) => {
    Object.assign(all.constants, require(`./${dir}/constants`));
-   all[dir] = require(`./${dir}`);
+   all[dir.replace(/-(.)/g, ([_all, chr]) => String(chr).toUpperCase())] = require(`./${dir}`);
 
    return all;
 }, { constants: {} });

--- a/test/unit/__fixtures__/remote-messages/constants.js
+++ b/test/unit/__fixtures__/remote-messages/constants.js
@@ -1,0 +1,4 @@
+
+module.exports = {
+
+};

--- a/test/unit/__fixtures__/remote-messages/index.js
+++ b/test/unit/__fixtures__/remote-messages/index.js
@@ -1,0 +1,4 @@
+
+module.exports = {
+   objectEnumeration: require('./object-enumeration'),
+}

--- a/test/unit/__fixtures__/remote-messages/object-enumeration.js
+++ b/test/unit/__fixtures__/remote-messages/object-enumeration.js
@@ -1,0 +1,12 @@
+const {createFixture} = require('../../../helpers');
+
+const stdErr = `
+remote: Enumerating objects: 5, done.
+remote: Counting objects: 100% (5/5), done.
+remote: Compressing objects: 100% (3/3), done.
+remote: Total 5 (delta 2), reused 5 (delta 2), pack-reused 0
+`;
+
+module.exports = createFixture(
+   '', stdErr,
+);

--- a/test/unit/merge.spec.js
+++ b/test/unit/merge.spec.js
@@ -75,8 +75,10 @@ Automatic merge failed; fix conflicts and then commit the result.
 
    describe('parser', () => {
 
+      let mergeSummary;
+
       it('successful merge with some files updated', () => {
-         const mergeSummary = parseMergeResult(`
+         givenTheResponse(`
 Updating 5826641..52c5cc6
 Fast-forward
  aaa.aaa | 2 +-
@@ -99,7 +101,7 @@ Fast-forward
       });
 
       it('multiple merges with some conflicts and some success', () => {
-         const mergeSummary = parseMergeResult(`
+         givenTheResponse(`
 Auto-merging ccc.ccc
 CONFLICT (add/add): Merge conflict in ccc.ccc
 Auto-merging bbb.bbb
@@ -125,7 +127,7 @@ Automatic merge failed; fix conflicts and then commit the result.
       });
 
       it('names conflicts when they exist', () => {
-         const mergeSummary = parseMergeResult(`
+         givenTheResponse(`
 Auto-merging readme.md
 CONFLICT (content): Merge conflict in readme.md
 Automatic merge failed; fix conflicts and then commit the result.
@@ -138,7 +140,7 @@ Automatic merge failed; fix conflicts and then commit the result.
       });
 
       it('names modify/delete conflicts when deleted by them', () => {
-         const mergeSummary = parseMergeResult(`
+         givenTheResponse(`
 Auto-merging readme.md
 CONFLICT (modify/delete): readme.md deleted in origin/master and modified in HEAD. Version HEAD of readme.md left in tree.
 Automatic merge failed; fix conflicts and then commit the result.
@@ -154,7 +156,7 @@ Automatic merge failed; fix conflicts and then commit the result.
       });
 
       it('names modify/delete conflicts when deleted by us', () => {
-         const mergeSummary = parseMergeResult(`
+         givenTheResponse(`
 Auto-merging readme.md
 CONFLICT (modify/delete): readme.md deleted in HEAD and modified in origin/master. Version origin/master of readme.md left in tree.
 Automatic merge failed; fix conflicts and then commit the result.
@@ -168,6 +170,10 @@ Automatic merge failed; fix conflicts and then commit the result.
             }
          ]);
       });
+
+      function givenTheResponse (stdOut, stdErr = '') {
+         return mergeSummary = parseMergeResult(stdOut, stdErr);
+      }
 
    });
 

--- a/test/unit/remote-messages.spec.js
+++ b/test/unit/remote-messages.spec.js
@@ -1,8 +1,37 @@
 const {like} = require('../helpers');
 const {parseRemoteMessages} = require('../../src/lib/parsers/parse-remote-messages');
 const {gitHubAlertsUrl, gitHubPullRequest, gitLabPullRequest, pushNewBranch, pushNewBranchWithVulnerabilities} = require('./__fixtures__/push');
+const {objectEnumeration} = require('./__fixtures__/remote-messages');
 
 describe('remote-messages', () => {
+
+   it('detects object enumeration', () => {
+      const actual = parseRemoteMessages(...objectEnumeration.parserArgs);
+      expect(actual).toEqual(like({
+         remoteMessages: {
+            all: [
+               'Enumerating objects: 5, done.',
+               'Counting objects: 100% (5/5), done.',
+               'Compressing objects: 100% (3/3), done.',
+               'Total 5 (delta 2), reused 5 (delta 2), pack-reused 0',
+            ],
+            objects: {
+               enumerating: 5,
+               counting: 5,
+               compressing: 3,
+               total: {
+                  count: 5,
+                  delta: 2,
+               },
+               reused: {
+                  count: 5,
+                  delta: 2,
+               },
+               packReused: 0,
+            },
+         }
+      }))
+   })
 
    it('outputs all remote messages whether they are parsed or not', () => {
       const actual = parseRemoteMessages(...pushNewBranch.parserArgs);

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -1,5 +1,6 @@
 import {
    append,
+   asNumber,
    filterArray,
    filterFunction,
    filterHasLength,
@@ -9,6 +10,21 @@ import {
 } from "../../src/lib/utils";
 
 describe('utils', () => {
+
+   describe('asNumber', () => {
+      it('from nullables', () => {
+         expect(asNumber()).toBe(0);
+         expect(asNumber(undefined)).toBe(0);
+         expect(asNumber(undefined, 5)).toBe(5);
+         expect(asNumber(null)).toBe(0);
+         expect(asNumber(null, 5)).toBe(5);
+      });
+
+      it('from NaN', () => {
+         expect(asNumber('hello')).toBe(0);
+         expect(asNumber('hello', 5)).toBe(5);
+      });
+   });
 
    describe('content', () => {
 
@@ -79,7 +95,8 @@ describe('utils', () => {
 
       it('recognises functions', () => {
          expect(filterFunction(NOOP)).toBe(true);
-         expect(filterFunction(() => {})).toBe(true);
+         expect(filterFunction(() => {
+         })).toBe(true);
 
          expect(filterFunction({})).toBe(false);
       });

--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -201,7 +201,7 @@ export interface PullDetailSummary {
    deletions: number;
 }
 
-export interface PullResult {
+export interface PullDetail {
    /** Array of all files that are referenced in the pull */
    files: string[];
 
@@ -218,6 +218,9 @@ export interface PullResult {
 
    /** Array of file names that have been deleted */
    deleted: string[];
+}
+
+export interface PullResult extends PullDetail, RemoteMessageResult {
 }
 
 /**
@@ -358,8 +361,24 @@ export interface PushResultPushedItem {
    readonly alreadyUpdated: boolean;
 }
 
+export interface RemoteMessagesObjectEnumeration {
+   enumerating: number,
+   counting: number,
+   compressing: number,
+   total: {
+      count: number,
+      delta: number,
+   },
+   reused: {
+      count: number,
+      delta: number,
+   },
+   packReused: number,
+}
+
 export interface RemoteMessages {
    all: string[];
+   objects?: RemoteMessagesObjectEnumeration;
 }
 
 export interface PushResultRemoteMessages extends RemoteMessages {


### PR DESCRIPTION
Already supported in response to a `push`, add support for `remote: ` messages in the response to a `git pull`

Closes #485 