### PR TITLE
Fixed `OptionsValues` type to allow boolean values

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -13,7 +13,7 @@ export type TaskOptions<O extends Options = Options> = string[] | O;
 /**
  * Options supplied in most tasks as an optional trailing object
  */
-export type OptionsValues = null | string | number;
+export type OptionsValues = null | string | number | boolean;
 export type Options = Record<string, OptionsValues>;
 
 export type OptionFlags<FLAGS extends string, VALUE = null> = Partial<Record<FLAGS, VALUE>>;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -13,7 +13,7 @@ export type TaskOptions<O extends Options = Options> = string[] | O;
 /**
  * Options supplied in most tasks as an optional trailing object
  */
-export type OptionsValues = null | string | number | boolean;
+export type OptionsValues = null | string | number;
 export type Options = Record<string, OptionsValues>;
 
 export type OptionFlags<FLAGS extends string, VALUE = null> = Partial<Record<FLAGS, VALUE>>;

--- a/test/unit/task-options.spec.ts
+++ b/test/unit/task-options.spec.ts
@@ -39,7 +39,7 @@ describe('task-options', () => {
       it('appends correct task options', () => {
          expect(appendTaskOptions({})).toEqual([])
          expect(appendTaskOptions({ foo: 'bar', number: 1 })).toEqual(["foo=bar", "number=1"])
-         expect(appendTaskOptions({ bool: true, foo: 'bar' })).toEqual(["bool", "foo=bar"])
+         expect(appendTaskOptions({ bool: null, foo: 'bar' })).toEqual(["bool", "foo=bar"])
       })
    });
 });

--- a/test/unit/task-options.spec.ts
+++ b/test/unit/task-options.spec.ts
@@ -1,36 +1,45 @@
-import { getTrailingOptions } from '../../src/lib/utils';
+import { getTrailingOptions, appendTaskOptions } from '../../src/lib/utils';
 
 describe('task-options', () => {
+   describe('getTrailingOptions', () => {
+      function callback () {}
 
-   function callback () {}
+      it.each([
+         test('no options supplied', [], []),
+         test('just callback supplied', [], [callback]),
+         test('just primitives supplied', [], ['hello', 'world']),
+         test('just primitives when 0 included', [], ['a', 'b', 'c'], 0),
+         test('just primitives when 2 included', ['a', 'b'], ['a', 'b', 'c'], 2),
+         test('just primitives when all included', ['a', 'b', 'c'], ['a', 'b', 'c'], -1),
+         test('just primitives sround others', ['a', 'c'], ['a', {a:'b'}, 'c'], -1),
 
-   it.each([
-      test('no options supplied', [], []),
-      test('just callback supplied', [], [callback]),
-      test('just primitives supplied', [], ['hello', 'world']),
-      test('just primitives when 0 included', [], ['a', 'b', 'c'], 0),
-      test('just primitives when 2 included', ['a', 'b'], ['a', 'b', 'c'], 2),
-      test('just primitives when all included', ['a', 'b', 'c'], ['a', 'b', 'c'], -1),
-      test('just primitives sround others', ['a', 'c'], ['a', {a:'b'}, 'c'], -1),
+         test('options array as last argument', ['b'], ['a', ['b']]),
+         test('options array behind callback', ['b'], ['a', ['b'], callback]),
 
-      test('options array as last argument', ['b'], ['a', ['b']]),
-      test('options array behind callback', ['b'], ['a', ['b'], callback]),
+         test('options object as last argument', ['b'], ['a', {b: null}]),
+         test('options object with values last argument', ['b=c'], ['a', {b: 'c'}]),
+         test('options object behind callback', ['b'], ['a', {b: null}, callback]),
+         test('options object with values behind callback', ['b=c'], ['a', {b: 'c'}, callback]),
 
-      test('options object as last argument', ['b'], ['a', {b: null}]),
-      test('options object with values last argument', ['b=c'], ['a', {b: 'c'}]),
-      test('options object behind callback', ['b'], ['a', {b: null}, callback]),
-      test('options object with values behind callback', ['b=c'], ['a', {b: 'c'}, callback]),
+         test('primitive: string and array', ['a', 'c'], ['a', 'b', ['c']], 1),
+         test('primitive: number', ['1', 'c'], [1, 'a', 'b', ['c']], 1),
+      ])('Default primitives %s', (name, {expected, args}) => {
+         expect(getTrailingOptions(...args)).toEqual(expected);
+      });
 
-      test('primitive: string and array', ['a', 'c'], ['a', 'b', ['c']], 1),
-      test('primitive: number', ['1', 'c'], [1, 'a', 'b', ['c']], 1),
-   ])('Default primitives %s', (name, {expected, args}) => {
-      expect(getTrailingOptions(...args)).toEqual(expected);
+      function test(name: string, expected: string[], args: any, includeInitialPrimitives?: number) {
+         return [name, {
+            expected,
+            args: typeof includeInitialPrimitives === 'number' ? [args, includeInitialPrimitives] : [args],
+         }];
+      }
+   })
+
+   describe("appendTaskOptions", () => {
+      it('appends correct task options', () => {
+         expect(appendTaskOptions({})).toEqual([])
+         expect(appendTaskOptions({ foo: 'bar', number: 1 })).toEqual(["foo=bar", "number=1"])
+         expect(appendTaskOptions({ bool: true, foo: 'bar' })).toEqual(["bool", "foo=bar"])
+      })
    });
-
-   function test(name: string, expected: string[], args: any, includeInitialPrimitives?: number) {
-      return [name, {
-         expected,
-         args: typeof includeInitialPrimitives === 'number' ? [args, includeInitialPrimitives] : [args],
-      }];
-   }
 });


### PR DESCRIPTION
In `appendTaskOptions` `boolean` is allowed as an option-value which is not the case for TS typings

Here `boolean` values are not filtered out and are later appended to the command:
https://github.com/steveukx/git-js/blob/68280a0fa38bd827e76f6955df274a7906306cc9/src/lib/utils/task-options.ts#L10-L19

Usage in `log` command:
https://github.com/steveukx/git-js/blob/master/src/git.js#L961