### PR TITLE
Add git.hashObject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage/
 *.bak
 *.log
 *.tsbuildinfo
+package-lock.json
 
 src/lib/**/*.js
 src/lib/**/*.map

--- a/src/git.js
+++ b/src/git.js
@@ -23,6 +23,7 @@ const {addSubModuleTask, initSubModuleTask, subModuleTask, updateSubModuleTask} 
 const {addAnnotatedTagTask, addTagTask, tagListTask} = require('./lib/tasks/tag');
 const {straightThroughStringTask} = require('./lib/tasks/task');
 const {parseCheckIgnore} = require('./lib/responses/CheckIgnore');
+const {hashObjectTask} = require('./lib/tasks/hash-object');
 
 const ChainedExecutor = Symbol('ChainedExecutor');
 
@@ -1061,6 +1062,19 @@ Git.prototype._runTask = function (task, then) {
       catch: {value: promise.catch.bind(promise)},
       [ChainedExecutor]: {value: executor},
    });
+};
+
+/**
+ * Compute object ID from a file
+ *
+ * @param {string} path
+ * @param {Function} [then]
+ */
+Git.prototype.hashObject = function (path, then) {
+   return this._runTask(
+      hashObjectTask(path),
+      trailingFunctionArgument(arguments),
+   );
 };
 
 /**

--- a/src/lib/tasks/hash-object.ts
+++ b/src/lib/tasks/hash-object.ts
@@ -1,0 +1,10 @@
+import { StringTask, straightThroughStringTask } from './task';
+
+/**
+ * Task used by `git.hashObject`
+ */
+export function hashObjectTask (filePath: string): StringTask<string> {
+   const commands = ['hash-object', filePath];
+
+   return straightThroughStringTask(commands, true);
+}

--- a/test/unit/hash-object.spec.ts
+++ b/test/unit/hash-object.spec.ts
@@ -1,0 +1,21 @@
+import { SimpleGit } from '../../typings/simple-git';
+import { assertExecutedCommands } from './__fixtures__/expectations';
+const {restore, newSimpleGit, closeWithSuccess} = require('./include/setup');
+
+describe('hash-object', () => {
+   let git: SimpleGit;
+
+   beforeEach(() => git = newSimpleGit());
+
+   afterEach(() => restore());
+
+   it('trims the output', async () => {
+     const task = git.hashObject('index.js');
+     await closeWithSuccess(`
+3b18e512dba79e4c8300dd08aeb37f8e728b8dad
+     `);
+
+     assertExecutedCommands('hash-object', 'index.js');
+     expect(await task).toEqual('3b18e512dba79e4c8300dd08aeb37f8e728b8dad');
+   })
+});

--- a/typings/simple-git.d.ts
+++ b/typings/simple-git.d.ts
@@ -228,6 +228,11 @@ export interface SimpleGit {
    getRemotes(verbose: true, callback?: types.SimpleGitTaskCallback<types.RemoteWithRefs[]>): Response<types.RemoteWithRefs[]>;
 
    /**
+    * Compute object ID from a file
+    */
+   hashObject(path: string, callback?: types.SimpleGitTaskCallback<void>): Response<string>;
+
+   /**
     * Initialize a git repo
     */
    init(bare: boolean, options?: types.TaskOptions, callback?: types.SimpleGitTaskCallback<resp.InitResult>): Response<resp.InitResult>;


### PR DESCRIPTION
Add git.hashObject. The `hash-object` command is used to compute object ID from a file.