### PR TITLE
Debug destroy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
            if: steps.cache-modules.outputs.cache-hit != 'true'
            env:
               GIT_AUTHOR_NAME: "Simple Git Tests"
-              GIT_AUTHOR_EMAIL: "tests@simple-git"
+              GIT_AUTHOR_EMAIL: "tests@simple-git.dev"
            run: |
                yarn
                yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
    push:
-      branches: [ master ]
+      branches: [ main ]
    pull_request:
-      branches: [ master ]
+      branches: [ main ]
 
 jobs:
    build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
              key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
          - name: Dependencies
            if: steps.cache-modules.outputs.cache-hit != 'true'
-           run: yarn
-         - run: echo "::set-env name=GIT_AUTHOR_NAME::Simple Git Tests"
-         - run: echo "::set-env name=GIT_AUTHOR_EMAIL::tests@simple-git.dev"
-         - name: Build
-           run: yarn build
-         - name: Test
-           run: yarn test
+           env:
+              GIT_AUTHOR_NAME: "Simple Git Tests"
+              GIT_AUTHOR_EMAIL: "tests@simple-git"
+           run: |
+               yarn
+               yarn build
+               yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Change History & Release Notes
 
+## 2.23.0 update `debug` dependency & `master` -> `main`
+
+- Upgrade `debug` dependency and remove use of now deprecated `debug().destroy()`
+- Renames the default source branch from `master` to `main`
+
 ## 2.22.0 add `git.hashObject` interface
 
 - Adds support for `git hash-object FILE` and `git hash-object -w FILE`

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@kwsites/file-exists": "^1.1.1",
     "@kwsites/promise-deferred": "^1.1.1",
-    "debug": "^4.1.1"
+    "debug": "^4.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.10.1",

--- a/src/lib/git-logger.ts
+++ b/src/lib/git-logger.ts
@@ -64,12 +64,10 @@ export function createLogger (label: string, verbose?: string | Debugger, initia
    const spawned: OutputLogger[] = [];
    const debugDebugger: Maybe<Debugger> = (typeof verbose === 'string') ? infoDebugger.extend(verbose) : verbose;
    const key = childLoggerName(filterType(verbose, filterString), debugDebugger, infoDebugger);
-   const kill = (debugDebugger?.destroy || NOOP).bind(debugDebugger);
 
    return step(initialStep);
 
    function destroy() {
-      kill();
       spawned.forEach(logger => logger.destroy());
       spawned.length = 0;
    }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,6 +2011,13 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -3470,6 +3477,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 ms@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Update `debug` dependency
Remove use of deprecated `debug().destroy()` - Closes #524
Renames the default source branch from `master` to `main`