### PR TITLE
Bug fix for git.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Change History & Release Notes
 
+## 2.26.0 Fix error when using `git.log` with callback
+
+- Resolves an issue whereby using `git.log` with a callback (or awaiting the promise created from the now deprecated
+  `simple-git/promise` import) would fail to return the response to the caller. 
+
 ## 2.25.0 TypeScript Types & Unit Tests, Commit Parsing
 
 - To help keep the TypeScript definitions in line with functionality, unit tests are now written in TypeScript.

--- a/src/git.js
+++ b/src/git.js
@@ -874,7 +874,8 @@ Git.prototype.log = function (options) {
    );
 
    return this._runTask(
-      logTask(parsedOptions.splitter, parsedOptions.fields, parsedOptions.commands)
+      logTask(parsedOptions.splitter, parsedOptions.fields, parsedOptions.commands),
+      next,
    )
 };
 

--- a/test/unit/log.spec.ts
+++ b/test/unit/log.spec.ts
@@ -491,7 +491,14 @@ ${START_BOUNDARY}207601debebc170830f2921acf2b6b27034c3b1f::2016-01-03 15:50:58 +
       }
    });
 
-   describe('usage:await', () => {
+   describe('usage:', () => {
+
+      it('passes result to callback', async () => {
+         const then = jest.fn();
+         const task = git.log(['--some-option'], then);
+         await closeWithSuccess();
+         expect(then).toHaveBeenCalledWith(null, await task);
+      });
 
       it('when awaiting array option', async () => {
          git.log(['--all']);


### PR DESCRIPTION
Resolves an issue whereby using `git.log` with a callback (or awaiting the promise created from the now deprecated `simple-git/promise` import) would fail to return the response to the caller.

Closes #536