### PR TITLE
Git.status parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Change History & Release Notes
 
+## 2.27.0 Included staged delete/modify in StatusResult staged array  
+
+-  Update the `git.status` parser to account for staged deleted/modified files and staged files with subsequent
+   modifications meaning a status of:
+   - `RM old -> new` will now appear in `renamed` and `new` will also appear in `modified`
+   - `D  file` will now appear in both `deleted` and `staged` where ` D file` would only appear in `deleted`
+  
 ## 2.26.0 Fix error when using `git.log` with callback
 
 - Resolves an issue whereby using `git.log` with a callback (or awaiting the promise created from the now deprecated

--- a/src/lib/tasks/status.ts
+++ b/src/lib/tasks/status.ts
@@ -1,7 +1,8 @@
+import { StatusResult } from '../../../typings';
+import { parseStatusSummary } from '../responses/StatusSummary';
 import { StringTask } from '../types';
-import { parseStatusSummary, StatusSummary } from '../responses/StatusSummary';
 
-export function statusTask(customArgs: string[]): StringTask<StatusSummary> {
+export function statusTask(customArgs: string[]): StringTask<StatusResult> {
    return {
       format: 'utf-8',
       commands: ['status', '--porcelain', '-b', '-u', ...customArgs],

--- a/test/unit/__fixtures__/index.ts
+++ b/test/unit/__fixtures__/index.ts
@@ -6,6 +6,7 @@ export * from './instance';
 export * from './responses/diff';
 export * from './responses/merge';
 export * from './responses/remote-messages';
+export * from './responses/status';
 
 export * from '../../__fixtures__/expectations'
 export * from '../../__fixtures__/like'

--- a/test/unit/__fixtures__/responses/status.ts
+++ b/test/unit/__fixtures__/responses/status.ts
@@ -1,0 +1,31 @@
+import { createFixture } from '../create-fixture';
+
+export function stagedRenamed(from = 'from.ext', to = 'to.ext', workingDir = ' ') {
+   return `R${workingDir} ${from} -> ${to}`;
+}
+
+export function stagedRenamedWithModifications(from = 'from.ext', to = 'to.ext') {
+   return stagedRenamed(from, to, 'M');
+}
+
+export function stagedDeleted(file = 'staged-deleted.ext') {
+   return `D  ${file}`;
+}
+
+export function unStagedDeleted(file = 'un-staged-deleted.ext') {
+   return ` D ${file}`;
+}
+
+export function stagedModified(file = 'staged-modified.ext') {
+   return `M  ${file}`;
+}
+
+export function statusResponse(branch = 'main', ...files: Array<string | (() => string)>) {
+   const stdOut: string[] = [
+      `## ${branch}`,
+      ...files.map(file => typeof file === 'function' ? file() : file),
+   ];
+
+   return createFixture(stdOut.join('\n'), '');
+
+}


### PR DESCRIPTION
- Updates the `StatusResult` response to `git.status` to reference staged deletions/modifications in the `staged` array
- Adds support in status parsing for staged rename with unstaged modifications
- Return type in `statusTask` to be interface rather than concrete class

Closes #530