### PR TITLE
Feature: handle initial commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Change History & Release Notes
 
+## 2.31.0 Handle 'root' commit syntax  
+
+- Adds a `root: boolean` property to the `CommitResult` interface representing whether the commit was a 'root' commit
+  (which is a commit that has no parent, most commonly the first commit in a repo).
+
 ## 2.30.0 Restore compatibility with Node.js v10
 
 - Reinstates native support for node.js v10 by removing use of ES6 constructs

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -26,7 +26,7 @@ declare namespace simplegit {
    type CleanMode = types.CleanMode;
    type DiffResult = resp.DiffResult;
    type FetchResult = resp.FetchResult;
-   type CommitSummary = resp.CommitSummary;
+   type CommitSummary = resp.CommitResult;
    type MergeResult = resp.MergeResult;
    type PullResult = resp.PullResult;
    type StatusResult = resp.StatusResult;

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -2,7 +2,6 @@ import * as errors from './typings/errors';
 import * as types from './typings/types';
 import * as resp from './typings/response';
 import * as simpleGit from './typings/simple-git';
-import { MergeResult } from './typings/response';
 
 declare const simplegit: simplegit.SimpleGitExport;
 
@@ -26,7 +25,7 @@ declare namespace simplegit {
    type CleanMode = types.CleanMode;
    type DiffResult = resp.DiffResult;
    type FetchResult = resp.FetchResult;
-   type CommitSummary = resp.CommitResult;
+   type CommitResult = resp.CommitResult;
    type MergeResult = resp.MergeResult;
    type PullResult = resp.PullResult;
    type StatusResult = resp.StatusResult;
@@ -40,6 +39,8 @@ declare namespace simplegit {
    // deprecated
    /** @deprecated use MergeResult */
    type MergeSummary = resp.MergeSummary;
+   /** @deprecated use CommitResult */
+   type CommitSummary = resp.CommitResult;
 }
 
 export = simplegit;

--- a/src/lib/parsers/parse-commit.ts
+++ b/src/lib/parsers/parse-commit.ts
@@ -1,10 +1,11 @@
-import { CommitSummary } from '../../../typings';
+import { CommitResult } from '../../../typings';
 import { LineParser, parseStringResponse } from '../utils';
 
-const parsers: LineParser<CommitSummary>[] = [
-   new LineParser(/\[([^\s]+) ([^\]]+)/, (result, [branch, commit]) => {
+const parsers: LineParser<CommitResult>[] = [
+   new LineParser(/\[([^\s]+)( \([^)]+\))? ([^\]]+)/, (result, [branch, root, commit]) => {
       result.branch = branch;
       result.commit = commit;
+      result.root = !!root;
    }),
    new LineParser(/\s*Author:\s(.+)/i, (result, [author]) => {
       const parts = author.split('<');
@@ -29,18 +30,18 @@ const parsers: LineParser<CommitSummary>[] = [
       const count = parseInt(lines, 10) || 0;
       if (direction === '-') {
          result.summary.deletions = count;
-      }
-      else if (direction === '+') {
+      } else if (direction === '+') {
          result.summary.insertions = count;
       }
    }),
 ];
 
-export function parseCommitResult(stdOut: string): CommitSummary {
-   const result: CommitSummary = {
+export function parseCommitResult(stdOut: string): CommitResult {
+   const result: CommitResult = {
       author: null,
       branch: '',
       commit: '',
+      root: false,
       summary: {
          changes: 0,
          insertions: 0,

--- a/src/lib/tasks/commit.ts
+++ b/src/lib/tasks/commit.ts
@@ -1,8 +1,8 @@
-import { CommitSummary } from '../../../typings';
+import { CommitResult } from '../../../typings';
 import { parseCommitResult } from '../parsers/parse-commit';
 import { StringTask } from '../types';
 
-export function commitTask(message: string[], files: string[], customArgs: string[]): StringTask<CommitSummary> {
+export function commitTask(message: string[], files: string[], customArgs: string[]): StringTask<CommitResult> {
    const commands: string[] = ['commit'];
 
    message.forEach((m) => commands.push('-m', m));

--- a/test/unit/__fixtures__/index.ts
+++ b/test/unit/__fixtures__/index.ts
@@ -2,6 +2,7 @@
 export * from './child-processes';
 export * from './expectations';
 
+export * from './responses/commit';
 export * from './responses/diff';
 export * from './responses/merge';
 export * from './responses/remote-messages';

--- a/test/unit/__fixtures__/responses/commit.ts
+++ b/test/unit/__fixtures__/responses/commit.ts
@@ -1,0 +1,26 @@
+export const commitResultSingleFile = `
+
+[foo 8f7d107] done
+Author: Some Author <some@author.com>
+1 files changed, 2 deletions(-)
+
+      `;
+
+export const commitResultNoneStaged = `
+On branch master
+        Your branch is ahead of 'origin/master' by 1 commit.
+           (use "git push" to publish your local commits)
+
+        Changes not staged for commit:
+           modified:   src/some-file.js
+           modified:   src/another-file.js
+        no changes added to commit
+        `;
+
+export function commitToRepoRoot ({message = 'Commit Message', hash = 'b13bdd8', fileName = 'file-name'} = {}) {
+   return `
+[master (root-commit) ${hash}] ${message}
+ 1 file changed, 1 insertion(+)
+ create mode 100644 ${fileName}
+`;
+}

--- a/test/unit/commit.spec.ts
+++ b/test/unit/commit.spec.ts
@@ -1,4 +1,12 @@
-import { assertExecutedCommands, closeWithSuccess, like, newSimpleGit } from './__fixtures__';
+import {
+   assertExecutedCommands,
+   closeWithSuccess,
+   commitResultNoneStaged,
+   commitResultSingleFile,
+   commitToRepoRoot,
+   like,
+   newSimpleGit
+} from './__fixtures__';
 import { SimpleGit } from '../../typings';
 import { parseCommitResult } from '../../src/lib/parsers/parse-commit';
 
@@ -72,29 +80,13 @@ describe('commit', () => {
    });
 
    describe('parsing', () => {
-      const commitResultSingleFile = `
-
-[foo 8f7d107] done
-Author: Some Author <some@author.com>
-1 files changed, 2 deletions(-)
-
-      `;
-
-      const commitResultNoneStaged = `On branch master
-        Your branch is ahead of 'origin/master' by 1 commit.
-           (use "git push" to publish your local commits)
-
-        Changes not staged for commit:
-           modified:   src/some-file.js
-           modified:   src/another-file.js
-        no changes added to commit
-        `;
 
       it('handles no files staged', () => {
          expect(parseCommitResult(commitResultNoneStaged)).toEqual({
             author: null,
             branch: '',
             commit: '',
+            root: false,
             summary: {
                changes: 0,
                insertions: 0,
@@ -132,8 +124,18 @@ Author: Some Author <some@author.com>
          expect(parseCommitResult(`[branchNameInHere CommitHash] Add nodeunit test runner`)).toEqual(like({
             branch: 'branchNameInHere',
             commit: 'CommitHash',
+            root: false,
          }));
       });
+
+      it('handles the root commit', () => {
+         const actual = parseCommitResult(commitToRepoRoot({hash: 'foo', message: 'bar'}));
+         expect(actual).toEqual(like({
+            branch: 'master',
+            commit: 'foo',
+            root: true
+         }));
+      })
 
    });
 

--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -68,13 +68,14 @@ export interface CleanSummary {
    folders: string[];
 }
 
-export interface CommitSummary {
+export interface CommitResult {
    author: null | {
       email: string;
       name: string;
    };
    branch: string;
    commit: string;
+   root: boolean;
    summary: {
       changes: number;
       insertions: number;
@@ -421,6 +422,12 @@ export interface PushDetail {
 
 export interface PushResult extends PushDetail, RemoteMessageResult<PushResultRemoteMessages> {
 }
+
+/**
+ * @deprecated
+ * For consistent naming, please use `CommitResult` instead of `CommitSummary`
+ */
+export type CommitSummary = CommitResult;
 
 /**
  * @deprecated

--- a/typings/simple-git.d.ts
+++ b/typings/simple-git.d.ts
@@ -184,21 +184,21 @@ export interface SimpleGit {
       message: string | string[],
       files?: string | string[],
       options?: types.Options,
-      callback?: types.SimpleGitTaskCallback<resp.CommitSummary>): Response<resp.CommitSummary>;
+      callback?: types.SimpleGitTaskCallback<resp.CommitResult>): Response<resp.CommitResult>;
 
    commit(
       message: string | string[],
       options?: types.TaskOptions,
-      callback?: types.SimpleGitTaskCallback<resp.CommitSummary>): Response<resp.CommitSummary>;
+      callback?: types.SimpleGitTaskCallback<resp.CommitResult>): Response<resp.CommitResult>;
 
    commit(
       message: string | string[],
       files?: string | string[],
-      callback?: types.SimpleGitTaskCallback<resp.CommitSummary>): Response<resp.CommitSummary>;
+      callback?: types.SimpleGitTaskCallback<resp.CommitResult>): Response<resp.CommitResult>;
 
    commit(
       message: string | string[],
-      callback?: types.SimpleGitTaskCallback<resp.CommitSummary>): Response<resp.CommitSummary>;
+      callback?: types.SimpleGitTaskCallback<resp.CommitResult>): Response<resp.CommitResult>;
 
    /**
     * Sets the path to a custom git binary, should either be `git` when there is an installation of git available on


### PR DESCRIPTION
- Adds support for detecting the `(root-commit)` token in response to a commit, representing a commit with no parent (ie: the initial commit).
- Renames `CommitSummary` to `CommitResult` (`CommitSummary` is now a deprecated alias of `CommitResult`)

Closes #520 