### PR TITLE
feat: split the `git.add` into the ts `SimpleGitApi`

### DIFF
--- a/src/lib/runners/git-executor-chain.ts
+++ b/src/lib/runners/git-executor-chain.ts
@@ -44,7 +44,11 @@ export class GitExecutorChain implements SimpleGitExecutor {
    ) {
    }
 
-   public push<R>(task: SimpleGitTask<R>): Promise<void | R> {
+   public chain() {
+      return this;
+   }
+
+   public push<R>(task: SimpleGitTask<R>): Promise<R> {
       this._queue.push(task);
 
       return this._chain = this._chain.then(() => this.attemptTask(task));

--- a/src/lib/runners/git-executor.ts
+++ b/src/lib/runners/git-executor.ts
@@ -1,7 +1,8 @@
+import { PluginStore } from '../plugins';
 import { GitExecutorEnv, outputHandler, SimpleGitExecutor, SimpleGitTask } from '../types';
+
 import { GitExecutorChain } from './git-executor-chain';
 import { Scheduler } from './scheduler';
-import { PluginStore } from '../plugins/plugin-store';
 
 export class GitExecutor implements SimpleGitExecutor {
 
@@ -22,7 +23,7 @@ export class GitExecutor implements SimpleGitExecutor {
       return new GitExecutorChain(this, this._scheduler, this._plugins);
    }
 
-   push<R>(task: SimpleGitTask<R>): Promise<void | R> {
+   push<R>(task: SimpleGitTask<R>): Promise<R> {
       return this._chain.push(task);
    }
 

--- a/src/lib/simple-git-api.ts
+++ b/src/lib/simple-git-api.ts
@@ -1,0 +1,35 @@
+import { SimpleGitBase } from '../../typings';
+import { straightThroughStringTask } from './tasks/task';
+import { SimpleGitExecutor, SimpleGitTask, SimpleGitTaskCallback } from './types';
+import { asArray, trailingFunctionArgument } from './utils';
+import { taskCallback } from './task-callback';
+
+export class SimpleGitApi implements SimpleGitBase {
+   private _executor: SimpleGitExecutor;
+
+   constructor(_executor: SimpleGitExecutor) {
+      this._executor = _executor;
+   }
+
+   private _runTask<T>(task: SimpleGitTask<T>, then?: SimpleGitTaskCallback<T>) {
+      const chain = this._executor.chain();
+      const promise = chain.push(task);
+
+      if (then) {
+         taskCallback(task, promise, then);
+      }
+
+      return Object.create(this, {
+         then: {value: promise.then.bind(promise)},
+         catch: {value: promise.catch.bind(promise)},
+         _executor: {value: chain},
+      });
+   }
+
+   add(files: string | string[]) {
+      return this._runTask(
+         straightThroughStringTask(['add', ...asArray(files)]),
+         trailingFunctionArgument(arguments),
+      );
+   }
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -49,7 +49,8 @@ export interface SimpleGitExecutor {
    binary: string;
    cwd: string;
 
-   push<R>(task: SimpleGitTask<R>): Promise<void | R>;
+   chain(): SimpleGitExecutor;
+   push<R>(task: SimpleGitTask<R>): Promise<R>;
 }
 
 /**

--- a/src/lib/utils/task-options.ts
+++ b/src/lib/utils/task-options.ts
@@ -57,7 +57,7 @@ export function trailingOptionsArgument<T extends any[]>(args: T): Maybe<Options
  * Returns either the source argument when it is a `Function`, or the default
  * `NOOP` function constant
  */
-export function trailingFunctionArgument(args: unknown[] | IArguments | unknown, includeNoop = true): Maybe<Function> {
+export function trailingFunctionArgument(args: unknown[] | IArguments | unknown, includeNoop = true): Maybe<(...args: any[]) => unknown> {
    const callback = asFunction(last(args));
    return includeNoop || isUserFunction(callback) ? callback : undefined;
 }

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -8,7 +8,7 @@ export const NOOP: (...args: any[]) => void = () => {
  * Returns either the source argument when it is a `Function`, or the default
  * `NOOP` function constant
  */
-export function asFunction<T extends Function>(source: T | any): T {
+export function asFunction<T extends () => any>(source: T | any): T {
    return typeof source === 'function' ? source : NOOP;
 }
 

--- a/test/unit/add.spec.ts
+++ b/test/unit/add.spec.ts
@@ -1,0 +1,34 @@
+import { SimpleGit } from '../../typings';
+import { assertExecutedCommands, closeWithSuccess, newSimpleGit } from './__fixtures__';
+
+describe('add', () => {
+
+   let git: SimpleGit;
+
+   beforeEach(() => git = newSimpleGit());
+
+   it('adds a single file', async () => {
+      const queue = git.add('file.ext');
+      await closeWithSuccess('raw response');
+
+      expect(await queue).toBe('raw response');
+      assertExecutedCommands('add', 'file.ext');
+   });
+
+   it('adds multiple files', async () => {
+      const queue = git.add(['file.one', 'file.two']);
+      await closeWithSuccess('raw response');
+
+      expect(await queue).toBe('raw response');
+      assertExecutedCommands('add', 'file.one', 'file.two');
+   });
+
+   it('adds files with trailing callback', async () => {
+      const callback = jest.fn();
+      const queue = git.add(['file.one', 'file.two'], callback);
+      await closeWithSuccess('raw response');
+
+      expect(await queue).toBe('raw response');
+      expect(callback).toHaveBeenCalledWith('raw response');
+   });
+});

--- a/typings/simple-git.d.ts
+++ b/typings/simple-git.d.ts
@@ -12,11 +12,15 @@ export interface SimpleGitFactory {
 
 type Response<T> = SimpleGit & Promise<T>;
 
-export interface SimpleGit {
+export interface SimpleGitBase {
    /**
     * Adds one or more files to source control
     */
-   add(files: string | string[], callback?: types.SimpleGitTaskCallback<void>): Response<void>;
+   add(files: string | string[], callback?: types.SimpleGitTaskCallback<string>): Response<string>;
+
+}
+
+export interface SimpleGit extends SimpleGitBase {
 
    /**
     * Add an annotated tag to the head of the current branch


### PR DESCRIPTION
Creates a base interface `SimpleGitBase` (extended by the existing `SimpleGit`) to act as the container for all methods moved to the wholly TypeScript interface.

Refactor `SimpleGit['add']` to `SimpleGitBase` & add unit tests