### PR TITLE
feat: Progress Handler

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,36 @@ const git: SimpleGit = simpleGit('/some/path', { config: ['http.proxy=someproxy'
 await git.pull();
 ```
 
+## Progress Events
+
+To receive progress updates, pass a `progress` configuration option to the `simpleGit` instance:
+
+```typescript
+import simpleGit, { SimpleGit, SimpleGitProgressEvent } from 'simple-git';
+
+const progress = ({method, stage, progress}: SimpleGitProgressEvent) => {
+   console.log(`git.${method} ${stage} stage ${progress}% complete`);
+}
+const git: SimpleGit = simpleGit({baseDir: '/some/path', progress});
+
+// pull automatically triggers progress events when the progress plugin is configured
+await git.pull();
+
+// supply the `--progress` option to any other command that supports it to receive
+// progress events into your handler
+await git.raw('pull', '--progress');
+```
+
+The `checkout`, `clone`, `pull`, `push` methods will automatically enable progress events when
+a progress handler has been set. For any other method that _can_ support progress events, set
+`--progress` in the task's `TaskOptions` for example to receive progress events when running
+submodule tasks:
+
+```typescript
+await git.submoduleUpdate('submodule-name', { '--progress': null });
+await git.submoduleUpdate('submodule-name', ['--progress']);
+```
+
 ## Using task callbacks
 
 Each of the methods in the API listing below can be called in a chain and will be called in series after each other.

--- a/src/git-factory.js
+++ b/src/git-factory.js
@@ -1,7 +1,9 @@
 const Git = require('./git');
+
 const {GitConstructError} = require('./lib/api');
 const {PluginStore} = require("./lib/plugins/plugin-store");
 const {commandConfigPrefixingPlugin} = require('./lib/plugins/command-config-prefixing-plugin');
+const {progressMonitorPlugin} = require('./lib/plugins/progress-monitor-plugin');
 const {createInstanceConfig, folderExists} = require('./lib/utils');
 
 const api = Object.create(null);
@@ -45,9 +47,11 @@ module.exports.gitInstanceFactory = function gitInstanceFactory (baseDir, option
       throw new GitConstructError(config, `Cannot use simple-git on a directory that does not exist`);
    }
 
-   if (config.config) {
+   if (Array.isArray(config.config)) {
       plugins.add(commandConfigPrefixingPlugin(config.config));
    }
+
+   config.progress && plugins.add(progressMonitorPlugin(config.progress));
 
    return new Git(config, plugins);
 };

--- a/src/lib/plugins/plugin-store.ts
+++ b/src/lib/plugins/plugin-store.ts
@@ -1,13 +1,16 @@
 import { SimpleGitPlugin, SimpleGitPluginType, SimpleGitPluginTypes } from './simple-git-plugin';
+import { asArray } from '../utils';
 
 export class PluginStore {
 
    private plugins: Set<SimpleGitPlugin<SimpleGitPluginType>> = new Set();
 
-   public add<T extends SimpleGitPluginType>(plugin: SimpleGitPlugin<T>) {
-      this.plugins.add(plugin);
+   public add<T extends SimpleGitPluginType>(plugin: SimpleGitPlugin<T> | SimpleGitPlugin<T>[]) {
+      const plugins = asArray(plugin);
+      plugins.forEach(plugin => this.plugins.add(plugin));
+
       return () => {
-         this.plugins.delete(plugin);
+         plugins.forEach(plugin => this.plugins.delete(plugin));
       };
    }
 

--- a/src/lib/plugins/progress-monitor-plugin.ts
+++ b/src/lib/plugins/progress-monitor-plugin.ts
@@ -1,0 +1,43 @@
+import { SimpleGitOptions } from '../types';
+import { asNumber, including } from '../utils';
+
+import { SimpleGitPlugin } from './simple-git-plugin';
+
+export function progressMonitorPlugin(progress: Exclude<SimpleGitOptions['progress'], void>) {
+   const progressCommand = '--progress';
+   const progressMethods = ['checkout', 'clone', 'pull'];
+
+   const onProgress: SimpleGitPlugin<'spawn.after'> = {
+      type: 'spawn.after',
+      action(_data, context) {
+         if (!context.commands.includes(progressCommand)) {
+            return;
+         }
+
+         context.spawned.stderr?.on('data', (chunk: Buffer) => {
+            const message = /Receiving objects:\s*(\d+)% \((\d+)\/(\d+)\)/.exec(chunk.toString('utf8'));
+            if (message) {
+               progress({
+                  method: context.method,
+                  progress: asNumber(message[1]),
+                  received: asNumber(message[2]),
+                  total: asNumber(message[3]),
+               });
+            }
+         });
+      }
+   };
+
+   const onArgs: SimpleGitPlugin<'spawn.args'> = {
+      type: 'spawn.args',
+      action(args, context) {
+         if (!progressMethods.includes(context.method)) {
+            return args;
+         }
+
+         return including(args, progressCommand);
+      }
+   }
+
+   return [onArgs, onProgress];
+}

--- a/src/lib/plugins/simple-git-plugin.ts
+++ b/src/lib/plugins/simple-git-plugin.ts
@@ -1,8 +1,21 @@
+import { ChildProcess } from 'child_process';
+
+type SimpleGitTaskPluginContext = {
+   readonly method: string;
+   readonly commands: string[];
+}
+
 export interface SimpleGitPluginTypes {
    'spawn.args': {
       data: string[];
-      context: {};
+      context: SimpleGitTaskPluginContext & {};
    };
+   'spawn.after': {
+      data: void;
+      context: SimpleGitTaskPluginContext & {
+         spawned: ChildProcess,
+      };
+   }
 }
 
 export type SimpleGitPluginType = keyof SimpleGitPluginTypes;

--- a/src/lib/types/handlers.ts
+++ b/src/lib/types/handlers.ts
@@ -9,3 +9,19 @@ export interface SimpleGitTaskCallback<T = string, E extends GitError = GitError
 
    (err: E): void;
 }
+
+/**
+ * The event data emitted to the progress handler whenever progress detail is received.
+ */
+export interface SimpleGitProgressEvent {
+   /** The underlying method called - push, pull etc */
+   method: string;
+   /** The type of progress being reported, note that any one task may emit many stages - for example `git clone` emits both `receiving` and `resolving` */
+   stage: 'compressing' | 'counting' | 'receiving' | 'resolving' | 'unknown' | 'writing' | string;
+   /** The percent progressed as a number 0 - 100 */
+   progress: number;
+   /** The number of items processed so far */
+   processed: number;
+   /** The total number of items to be processed */
+   total: number;
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,4 +1,5 @@
 import { SimpleGitTask } from './tasks';
+import { SimpleGitProgressEvent } from './handlers';
 
 export * from './handlers';
 export * from './tasks';
@@ -70,12 +71,7 @@ export interface SimpleGitOptions {
    maxConcurrentProcesses: number;
    config: string[];
 
-   progress?(data: {
-      method: string;
-      progress: number;
-      received: number;
-      total: number;
-   }): void;
+   progress?(data: SimpleGitProgressEvent): void;
 }
 
 export type Maybe<T> = T | undefined;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -37,9 +37,6 @@ export type outputHandler = (
 export type GitExecutorEnv = NodeJS.ProcessEnv | undefined;
 
 
-
-
-
 /**
  * Public interface of the Executor
  */
@@ -50,6 +47,7 @@ export interface SimpleGitExecutor {
    cwd: string;
 
    chain(): SimpleGitExecutor;
+
    push<R>(task: SimpleGitTask<R>): Promise<R>;
 }
 
@@ -71,6 +69,13 @@ export interface SimpleGitOptions {
    binary: string;
    maxConcurrentProcesses: number;
    config: string[];
+
+   progress?(data: {
+      method: string;
+      progress: number;
+      received: number;
+      total: number;
+   }): void;
 }
 
 export type Maybe<T> = T | undefined;

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -75,7 +75,7 @@ export function folderExists(path: string): boolean {
 }
 
 /**
- * Adds `item` into the `target` `Array` or `Set` when it is not already present.
+ * Adds `item` into the `target` `Array` or `Set` when it is not already present and returns the `item`.
  */
 export function append<T>(target: T[] | Set<T>, item: T): typeof item {
    if (Array.isArray(target)) {
@@ -86,6 +86,17 @@ export function append<T>(target: T[] | Set<T>, item: T): typeof item {
       target.add(item);
    }
    return item;
+}
+
+/**
+ * Adds `item` into the `target` `Array` when it is not already present and returns the `target`.
+ */
+export function including<T>(target: T[], item: T): typeof target {
+   if (Array.isArray(target) && !target.includes(item)) {
+      target.push(item);
+   }
+
+   return target;
 }
 
 export function remove<T>(target: Set<T> | T[], item: T): T {

--- a/test/integration/progress-plugin.spec.ts
+++ b/test/integration/progress-plugin.spec.ts
@@ -18,23 +18,26 @@ describe('progress-monitor', () => {
 
       await newSimpleGit(opt).clone(upstream);
 
-      const count = progress.mock.calls.length;
-      const last = progress.mock.calls[count - 1];
+      const receivingUpdates = progressEventsAtStage(progress, 'receiving');
 
-      expect(count).toBeGreaterThan(0);
-      expect(last[0]).toEqual({
-         method: 'clone',
-         progress: 100,
-         received: last[0].total,
-         total: expect.any(Number),
-      });
+      expect(receivingUpdates.length).toBeGreaterThan(0);
 
-      progress.mock.calls.reduce((previous, [{progress, method}]) => {
-         expect(method).toBe('clone');
-         expect(progress).toBeGreaterThanOrEqual(previous);
-         return progress;
+      receivingUpdates.reduce((previous, update) => {
+         expect(update).toEqual({
+            method: 'clone',
+            stage: 'receiving',
+            progress: expect.any(Number),
+            processed: expect.any(Number),
+            total: expect.any(Number),
+         });
+
+         expect(update.progress).toBeGreaterThanOrEqual(previous);
+         return update.progress;
       }, 0);
-
    });
 
-})
+});
+
+function progressEventsAtStage (mock: jest.Mock, stage: string) {
+   return mock.mock.calls.filter(c => c[0].stage === stage).map(c => c[0]);
+}

--- a/test/integration/progress-plugin.spec.ts
+++ b/test/integration/progress-plugin.spec.ts
@@ -1,0 +1,40 @@
+import { createTestContext, newSimpleGit, SimpleGitTestContext } from '../__fixtures__';
+import { SimpleGitOptions } from '../../src/lib/types';
+
+describe('progress-monitor', () => {
+
+   const upstream = 'https://github.com/steveukx/git-js.git';
+
+   let context: SimpleGitTestContext;
+
+   beforeEach(async () => context = await createTestContext());
+
+   it('emits progress events', async () => {
+      const progress = jest.fn();
+      const opt: Partial<SimpleGitOptions> = {
+         baseDir: context.root,
+         progress,
+      };
+
+      await newSimpleGit(opt).clone(upstream);
+
+      const count = progress.mock.calls.length;
+      const last = progress.mock.calls[count - 1];
+
+      expect(count).toBeGreaterThan(0);
+      expect(last[0]).toEqual({
+         method: 'clone',
+         progress: 100,
+         received: last[0].total,
+         total: expect.any(Number),
+      });
+
+      progress.mock.calls.reduce((previous, [{progress, method}]) => {
+         expect(method).toBe('clone');
+         expect(progress).toBeGreaterThanOrEqual(previous);
+         return progress;
+      }, 0);
+
+   });
+
+})

--- a/test/unit/__fixtures__/child-processes.ts
+++ b/test/unit/__fixtures__/child-processes.ts
@@ -4,6 +4,21 @@ import { wait } from '../../__fixtures__';
 const EXIT_CODE_SUCCESS = 0;
 const EXIT_CODE_ERROR = 1;
 
+export async function writeToStdErr (data = '') {
+   await wait();
+   const proc = mockChildProcessModule.$mostRecent();
+
+   if (!proc) {
+      throw new Error(`writeToStdErr unable to find matching child process`);
+   }
+
+   if (proc.$emitted('exit')) {
+      throw new Error('writeToStdErr: attempting to write to an already closed process');
+   }
+
+   proc.stderr.$emit('data', Buffer.from(data));
+}
+
 export async function closeWithError (stack = 'CLOSING WITH ERROR', code = EXIT_CODE_ERROR) {
    await wait();
    const match = mockChildProcessModule.$mostRecent();

--- a/test/unit/__fixtures__/expectations.ts
+++ b/test/unit/__fixtures__/expectations.ts
@@ -27,6 +27,10 @@ export function assertExecutedCommandsContains(command: string) {
    expect(mockChildProcessModule.$mostRecent().$args.indexOf(command)).not.toBe(-1);
 }
 
+export function assertExecutedCommandsContainsOnce(command: string) {
+   expect(mockChildProcessModule.$mostRecent().$args.filter(c => c === command)).toHaveLength(1);
+}
+
 export function assertChildProcessEnvironmentVariables(env: any) {
    expect(mockChildProcessModule.$mostRecent()).toHaveProperty('$env', env);
 }

--- a/test/unit/plugins.spec.ts
+++ b/test/unit/plugins.spec.ts
@@ -1,16 +1,109 @@
 import { SimpleGit } from '../../typings';
-import { assertExecutedCommands, closeWithSuccess, newSimpleGit } from './__fixtures__';
+import { assertExecutedCommands, closeWithSuccess, newSimpleGit, writeToStdErr } from './__fixtures__';
 
 describe('plugins', () => {
 
    let git: SimpleGit;
+   let fn: jest.Mock;
+
+   beforeEach(() => fn = jest.fn());
 
    it('allows configuration prefixing', async () => {
-      git = newSimpleGit({ config: ['a', 'bcd'] });
+      git = newSimpleGit({config: ['a', 'bcd']});
       git.raw('foo');
 
       await closeWithSuccess();
       assertExecutedCommands('-c', 'a', '-c', 'bcd', 'foo');
-   })
+   });
 
-})
+   describe('progress', () => {
+      it('clone - auto added command', async () => {
+         git = newSimpleGit({progress: fn});
+         git.clone('foo', ['abc']);
+
+         await writeToStdErr(`Receiving objects: 1% (2/200)`);
+
+         expect(fn).toBeCalledWith({
+            method: 'clone',
+            progress: 1,
+            received: 2,
+            total: 200,
+         });
+         assertExecutedCommands('clone', 'abc', 'foo', '--progress');
+      });
+
+      it('clone - already added command', async () => {
+         git = newSimpleGit({progress: fn});
+         git.clone('foo', ['--progress', 'abc']);
+
+         await writeToStdErr(`Receiving objects: 5% (5/100)`);
+
+         expect(fn).toBeCalledWith({
+            method: 'clone',
+            progress: 5,
+            received: 5,
+            total: 100,
+         });
+         assertExecutedCommands('clone', '--progress', 'abc', 'foo');
+      });
+
+      it('clone - emits progress multiple times to the same handler', async () => {
+         git = newSimpleGit({progress: fn});
+         git.clone('foo', ['--progress', 'abc']);
+
+         await writeToStdErr(`Receiving objects: 5% (1/20)`);
+         await writeToStdErr(`Receiving objects: 90% (18/20)`);
+         await writeToStdErr(`Receiving objects: 100% (20/20)`);
+
+         expect(fn.mock.calls.map(([data]) => data)).toEqual([
+            {method: 'clone', progress: 5, received: 1, total: 20},
+            {method: 'clone', progress: 90, received: 18, total: 20},
+            {method: 'clone', progress: 100, received: 20, total: 20},
+         ]);
+      });
+
+      it('raw - emits progress events whenever the --progress flag is used', async () => {
+         git = newSimpleGit({progress: fn});
+         git.raw('something', '--progress', 'foo');
+
+         await writeToStdErr(`Receiving objects: 5% (1/20)`);
+         await closeWithSuccess();
+
+         expect(fn).toHaveBeenCalledWith({
+            method: 'something',
+            progress: 5,
+            received: 1,
+            total: 20,
+         });
+      });
+
+      it('raw - no progress events emitted if --progress flag is not used', async () => {
+         git = newSimpleGit({progress: fn});
+         git.raw('something', 'foo');
+
+         await writeToStdErr(`Receiving objects: 5% (1/20)`);
+         await closeWithSuccess();
+
+         expect(fn).not.toHaveBeenCalled();
+      });
+
+      it('handles progress with custom config', async () => {
+         git = newSimpleGit({
+            progress: fn,
+            config: ['foo', '--progress', 'bar'],
+         });
+         git.raw('baz');
+
+         await writeToStdErr(`Receiving objects: 10% (100/1000)`);
+         await closeWithSuccess();
+
+         expect(fn).toHaveBeenCalledWith({
+            method: 'baz',
+            progress: 10,
+            received: 100,
+            total: 1000,
+         });
+      });
+   });
+
+});

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -7,7 +7,8 @@ import {
    filterPlainObject,
    filterPrimitives,
    first,
-   forEachLineWithContent, including,
+   forEachLineWithContent,
+   including,
    last,
    NOOP,
    toLinesWithContent
@@ -73,7 +74,7 @@ describe('utils', () => {
 
    describe('arrays', () => {
 
-      function test<T> (target: T[] | Set<T>, itemA: T, itemB: T) {
+      function test<T>(target: T[] | Set<T>, itemA: T, itemB: T) {
          expect(append(target, itemA)).toBe(itemA);
          expect(Array.from(target)).toEqual([itemA]);
 

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -7,7 +7,7 @@ import {
    filterPlainObject,
    filterPrimitives,
    first,
-   forEachLineWithContent,
+   forEachLineWithContent, including,
    last,
    NOOP,
    toLinesWithContent
@@ -87,15 +87,38 @@ describe('utils', () => {
       it('appends objects into an array', () => {
          test([], {a: 1}, {b: 1});
       });
+
       it('appends primitives into an array', () => {
          test<string>([], 'A', 'B');
       });
+
       it('appends objects into a set', () => {
          test(new Set(), {a: 1}, {b: 1});
       });
+
       it('appends primitives into a set', () => {
          test(new Set(), 'A', 'B');
       });
+   });
+
+   describe('including', () => {
+
+      it('does nothing when the item already exists', () => {
+         const input = ['abc', 'foo', 'bar'];
+         const output = including(input, 'foo');
+
+         expect(input).toBe(output);
+         expect(output).toEqual(['abc', 'foo', 'bar']);
+      });
+
+      it('appends when the item does not exist', () => {
+         const input = ['abc', 'bar'];
+         const output = including(input, 'foo');
+
+         expect(input).toBe(output);
+         expect(output).toEqual(['abc', 'bar', 'foo']);
+      });
+
    });
 
    describe('argument filtering', () => {


### PR DESCRIPTION
The `SimpleGitOptions` can now be used to supply a `progress` handler, called whenever progress data is received from one of the tasks. Setting the `progress` option will automatically add the `--progress` command to any `checkout` / `clone` or `pull` task when not already supplied in the `TaskOptions`.

For any task that ran with `--progress` as a command (ie: even `git.raw` so long as the `--progress` command was present), monitors the `stdErr` for progress data.