### PR TITLE
fix: Update configuration documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ Configure each `simple-git` instance with a properties object passed to the main
 ```typescript
 import simpleGit, { SimpleGit, SimpleGitOptions } from 'simple-git';
 
-const options: SimpleGitOptions = {
+const options: Partial<SimpleGitOptions> = {
    baseDir: process.cwd(),
    binary: 'git',
    maxConcurrentProcesses: 6,


### PR DESCRIPTION
fix: Update documentation for configuring `SimpleGit` - `options` should be a `Partial<SimpleGitOptions>` to allow for supplying just some of its properties.

closes #580