### PR TITLE
fix: parsing `git.branch` includes carriage returns

### DIFF
--- a/src/lib/parsers/parse-branch.ts
+++ b/src/lib/parsers/parse-branch.ts
@@ -10,7 +10,7 @@ const parsers: LineParser<BranchSummaryResult>[] = [
          name, commit, label
       );
    }),
-   new LineParser(/^(\*\s)?(\S+)\s+([a-z0-9]+)\s(.*)$/, (result, [current, name, commit, label]) => {
+   new LineParser(/^(\*\s)?(\S+)\s+([a-z0-9]+)\s(.*)$/s, (result, [current, name, commit, label]) => {
       result.push(
          !!current,
          false,

--- a/test/unit/__fixtures__/index.ts
+++ b/test/unit/__fixtures__/index.ts
@@ -2,6 +2,7 @@
 export * from './child-processes';
 export * from './expectations';
 
+export * from './responses/branch';
 export * from './responses/commit';
 export * from './responses/diff';
 export * from './responses/merge';

--- a/test/unit/__fixtures__/responses/branch.ts
+++ b/test/unit/__fixtures__/responses/branch.ts
@@ -1,0 +1,11 @@
+
+export function branchSummary (...lines: string[]) {
+   return lines.join('\n');
+}
+
+export function branchSummaryLine(commit: string, hash = '', current = false) {
+   const prefix = current ? '*' : ' ';
+   const branch = hash || commit.replace(/[^a-z]/i, '').substr(0, 5);
+
+   return `${prefix} branch-${branch} ${hash || branch.substr(0, 5)} ${commit}`;
+}

--- a/test/unit/branch.spec.ts
+++ b/test/unit/branch.spec.ts
@@ -1,5 +1,12 @@
 import { BranchSingleDeleteResult, BranchSummary, SimpleGit } from 'typings';
-import { assertExecutedCommands, closeWithSuccess, like, newSimpleGit } from './__fixtures__';
+import {
+   assertExecutedCommands,
+   branchSummary,
+   branchSummaryLine,
+   closeWithSuccess,
+   like,
+   newSimpleGit
+} from './__fixtures__';
 
 import { parseBranchSummary } from '../../src/lib/parsers/parse-branch';
 import { BranchSummaryResult } from '../../src/lib/responses/BranchSummary';
@@ -99,6 +106,37 @@ describe('branch', () => {
    });
 
    describe('parsing', () => {
+
+      it('handles branches with carriage returns in the commit message', async () => {
+         expect(parseBranchSummary(branchSummary(
+            branchSummaryLine('Something', '012de2', false),
+            branchSummaryLine('Add support for carriage \r returns', '012de3', true),
+            branchSummaryLine('Something else', '012de4', false),
+         ))).toEqual(like({
+            branches: {
+               'branch-012de2': {
+                  commit: '012de2',
+                  current: false,
+                  label: 'Something',
+                  name: 'branch-012de2',
+               },
+               'branch-012de3': {
+                  commit: '012de3',
+                  current: true,
+                  label: 'Add support for carriage \r returns',
+                  name: 'branch-012de3',
+               },
+               'branch-012de4': {
+                  commit: '012de4',
+                  current: false,
+                  label: 'Something else',
+                  name: 'branch-012de4',
+               },
+            }
+         }))
+      });
+
+
 
       it('branch detail by name', async () => {
          const actual = parseBranchSummary(`


### PR DESCRIPTION


Closes #596
Closes #500 