### PR TITLE
Supply stdOut also to error handler

### DIFF
--- a/src/lib/runners/git-executor-chain.ts
+++ b/src/lib/runners/git-executor-chain.ts
@@ -135,7 +135,7 @@ export class GitExecutorChain implements SimpleGitExecutor {
 
          if (failed) {
             logger.info(`handling as error: exitCode=%s stdErr=%s rejection=%o`, exitCode, stdErr.length, rejection);
-            return fail(rejection || Buffer.concat(stdErr).toString('utf-8'));
+            return fail(rejection || Buffer.concat([...stdOut, ...stdErr]).toString('utf-8'));
          }
 
          if (concatStdErr) {


### PR DESCRIPTION
Currently when an error happens the error message only includes `stdErr`. In some cases (at least `push`) `stdOut` would be very handy to also have in the message because it contains the actual reason why something failed.
It appeared in renovatebot/renovate#8354 that we are not able to push because of permission problems, but the error handler in our code cannot handle the error because the reason is only printed to `stdOut` by git and therefore not in the error message.

To prove what is logged by `git` I add a `console.log` statement to  https://github.com/steveukx/git-js/blob/main/src/lib/runners/git-executor-chain.ts#L242-L248 and this is what I see.

```
stdErr ---> Pushing to https://edcd21d09ed4ed5d6d24e7b05369459ea2ccb17f@github.com/reactjs/react-tabs.git

stdErr ---> POST git-receive-pack (929 bytes)

stdErr ---> error: failed to push some refs to 'https://edcd21d09ed4ed5d6d24e7b05369459ea2ccb17f@github.com/reactjs/react-tabs.git'

stdOut ---> To https://github.com/reactjs/react-tabs.git
!       refs/heads/renovate/jamesives-github-pages-deploy-action-4.x:refs/heads/renovate/jamesives-github-pages-deploy-action-4.x       [remote rejected] (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/build.yml` without `workflow` scope)
Done
```

The fix simple concats `stdErr` and `stdOut`, so that the error message in the end has both.

Is this okay?

Ideally `stdOut` and `stdError` would be properties of the thrown Error (similar to [execa](https://github.com/sindresorhus/execa#handling-errors)), but that would be a way bigger undertaking.