### PR TITLE
Feature/error detection plugin

### DIFF
--- a/docs/PLUGIN-ERRORS.md
+++ b/docs/PLUGIN-ERRORS.md
@@ -1,0 +1,33 @@
+## Custom Error Detection
+
+By default, `simple-git` will determine that a `git` task has resulted in an error when the process exit
+code is anything other than `0` and there has been some data sent to the `stdErr` stream. Error handlers
+will be passed the content of both `stdOut` and `stdErr` concatenated together. 
+
+To change any of this behaviour, configure the `simple-git` with the `errors` plugin with a function to be
+called after every task has been run and should return either `undefined` when the task is treated as
+a success, or a `Buffer` or `Error` when the task should be treated as a failure.
+
+When the default error handler (or any other plugin) has thrown an error, the first argument to the error
+detection plugin is the original error. Either return that error directly to allow it to bubble up to the
+task's error handlers, or implement your own error detection as below:
+
+```typescript
+import simpleGit from 'simple-git';
+
+const git = simpleGit({
+   errors(error, result) {
+      // optionally pass through any errors reported before this plugin runs
+      if (error) return error;
+
+      // customise the `errorCode` values to treat as success
+      if (result.errorCode === 0) {
+         return;
+      }
+
+      // the default error messages include both stdOut and stdErr, but that
+      // can be changed here, or completely replaced with some other content
+      return Buffer.concat([...result.stdOut, ...result.stdErr]);
+   }
+})
+```

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,9 @@ await git.pull();
 
 ## Configuring Plugins
 
+- [Error Detection](./docs/PLUGIN-ERRORS.md)
+  Customise the detection of errors from the underlying `git` process.
+
 - [Progress Events](./docs/PLUGIN-PROGRESS-EVENTS.md)
   Receive progress events as `git` works through long-running processes.
 

--- a/src/lib/git-factory.ts
+++ b/src/lib/git-factory.ts
@@ -47,6 +47,7 @@ export function gitInstanceFactory(baseDir?: string | Partial<SimpleGitOptions>,
    config.progress && plugins.add(progressMonitorPlugin(config.progress));
    config.timeout && plugins.add(timeoutPlugin(config.timeout));
 
+   plugins.add(errorDetectionPlugin({}));
    plugins.add(errorDetectionPlugin(config.errors || {}));
 
    return new Git(config, plugins);

--- a/src/lib/git-factory.ts
+++ b/src/lib/git-factory.ts
@@ -1,11 +1,11 @@
-const Git = require('../git');
-
 import { SimpleGitFactory } from '../../typings';
 
 import api from './api';
-import { commandConfigPrefixingPlugin, PluginStore, progressMonitorPlugin, timeoutPlugin } from './plugins';
+import { commandConfigPrefixingPlugin, errorDetectionPlugin, PluginStore, progressMonitorPlugin, timeoutPlugin } from './plugins';
 import { createInstanceConfig, folderExists } from './utils';
 import { SimpleGitOptions } from './types';
+
+const Git = require('../git');
 
 /**
  * Adds the necessary properties to the supplied object to enable it for use as
@@ -46,6 +46,8 @@ export function gitInstanceFactory(baseDir?: string | Partial<SimpleGitOptions>,
 
    config.progress && plugins.add(progressMonitorPlugin(config.progress));
    config.timeout && plugins.add(timeoutPlugin(config.timeout));
+
+   plugins.add(errorDetectionPlugin(config.errors || {}));
 
    return new Git(config, plugins);
 }

--- a/src/lib/git-factory.ts
+++ b/src/lib/git-factory.ts
@@ -1,7 +1,14 @@
 import { SimpleGitFactory } from '../../typings';
 
 import api from './api';
-import { commandConfigPrefixingPlugin, errorDetectionPlugin, PluginStore, progressMonitorPlugin, timeoutPlugin } from './plugins';
+import {
+   commandConfigPrefixingPlugin,
+   errorDetectionHandler,
+   errorDetectionPlugin,
+   PluginStore,
+   progressMonitorPlugin,
+   timeoutPlugin
+} from './plugins';
 import { createInstanceConfig, folderExists } from './utils';
 import { SimpleGitOptions } from './types';
 
@@ -47,8 +54,8 @@ export function gitInstanceFactory(baseDir?: string | Partial<SimpleGitOptions>,
    config.progress && plugins.add(progressMonitorPlugin(config.progress));
    config.timeout && plugins.add(timeoutPlugin(config.timeout));
 
-   plugins.add(errorDetectionPlugin({}));
-   plugins.add(errorDetectionPlugin(config.errors || {}));
+   plugins.add(errorDetectionPlugin(errorDetectionHandler(true)));
+   config.errors && plugins.add(errorDetectionPlugin(config.errors));
 
    return new Git(config, plugins);
 }

--- a/src/lib/parsers/parse-branch-delete.ts
+++ b/src/lib/parsers/parse-branch-delete.ts
@@ -22,8 +22,8 @@ const parsers: LineParser<BranchMultiDeleteResult>[] = [
    }),
 ];
 
-export const parseBranchDeletions: TaskParser<string, BranchMultiDeleteResult> = (stdOut: string) => {
-   return parseStringResponse(new BranchDeletionBatch(), parsers, stdOut);
+export const parseBranchDeletions: TaskParser<string, BranchMultiDeleteResult> = (stdOut, stdErr) => {
+   return parseStringResponse(new BranchDeletionBatch(), parsers, stdOut, stdErr);
 }
 
 export function hasBranchDeletionError(data: string, processExitCode: ExitCodes): boolean {

--- a/src/lib/plugins/error-detection.plugin.ts
+++ b/src/lib/plugins/error-detection.plugin.ts
@@ -12,7 +12,7 @@ function getErrorMessage (result: TaskResult) {
    return Buffer.concat([...result.stdOut, ...result.stdErr]);
 }
 
-function taskErrorPlugin (overwrite = false, isError = isTaskError, errorMessage: (result: TaskResult) => Buffer | Error = getErrorMessage) {
+export function errorDetectionHandler (overwrite = false, isError = isTaskError, errorMessage: (result: TaskResult) => Buffer | Error = getErrorMessage) {
 
    return (error: Buffer | Error | undefined, result: TaskResult) => {
       if ((!overwrite && error) || !isError(result)) {
@@ -24,10 +24,6 @@ function taskErrorPlugin (overwrite = false, isError = isTaskError, errorMessage
 }
 
 export function errorDetectionPlugin(config: SimpleGitPluginConfig['errors']): SimpleGitPlugin<'task.error'> {
-
-   if (typeof config !== 'function') {
-      return errorDetectionPlugin(taskErrorPlugin(config.overwrite, config.isError, config.errorMessage));
-   }
 
    return {
       type: 'task.error',

--- a/src/lib/plugins/error-detection.plugin.ts
+++ b/src/lib/plugins/error-detection.plugin.ts
@@ -1,0 +1,25 @@
+import { GitError } from '../errors/git-error';
+import { SimpleGitPluginConfig } from '../types';
+import { SimpleGitPlugin } from './simple-git-plugin';
+
+export function errorDetectionPlugin({
+                                        streams: {stdOut, stdErr}
+                                     }: SimpleGitPluginConfig['errors']): SimpleGitPlugin<'task.error'> {
+   return {
+      type: 'task.error',
+      action(data, context) {
+         if (data.error) {
+            return data;
+         }
+
+         const error = [
+            ...(stdOut !== false && context.stdOut || []),
+            ...(stdErr !== false && context.stdErr || []),
+         ];
+
+         return {
+            error: new GitError(undefined, Buffer.concat(error).toString('utf-8')),
+         };
+      },
+   }
+}

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -1,4 +1,5 @@
 export * from './command-config-prefixing-plugin';
+export * from './error-detection.plugin';
 export * from './plugin-store';
 export * from './progress-monitor-plugin';
 export * from './simple-git-plugin';

--- a/src/lib/plugins/simple-git-plugin.ts
+++ b/src/lib/plugins/simple-git-plugin.ts
@@ -19,7 +19,7 @@ export interface SimpleGitPluginTypes {
       };
    },
    'task.error': {
-      data: { error?: Error | Buffer };
+      data: { error?: Error };
       context: SimpleGitTaskPluginContext & GitExecutorResult;
    },
 }

--- a/src/lib/plugins/simple-git-plugin.ts
+++ b/src/lib/plugins/simple-git-plugin.ts
@@ -1,4 +1,5 @@
 import { ChildProcess } from 'child_process';
+import { GitExecutorResult } from '../types';
 
 type SimpleGitTaskPluginContext = {
    readonly method: string;
@@ -16,7 +17,11 @@ export interface SimpleGitPluginTypes {
          spawned: ChildProcess;
          kill (reason: Error): void;
       };
-   }
+   },
+   'task.error': {
+      data: { error?: Error | string };
+      context: SimpleGitTaskPluginContext & GitExecutorResult;
+   },
 }
 
 export type SimpleGitPluginType = keyof SimpleGitPluginTypes;

--- a/src/lib/plugins/simple-git-plugin.ts
+++ b/src/lib/plugins/simple-git-plugin.ts
@@ -19,7 +19,7 @@ export interface SimpleGitPluginTypes {
       };
    },
    'task.error': {
-      data: { error?: Error | string };
+      data: { error?: Error | Buffer };
       context: SimpleGitTaskPluginContext & GitExecutorResult;
    },
 }

--- a/src/lib/runners/git-executor-chain.ts
+++ b/src/lib/runners/git-executor-chain.ts
@@ -135,7 +135,7 @@ export class GitExecutorChain implements SimpleGitExecutor {
 
          if (failed) {
             logger.info(`handling as error: exitCode=%s stdErr=%s rejection=%o`, exitCode, stdErr.length, rejection);
-            return fail(rejection || Buffer.concat(stdErr).toString('utf-8'));
+            return fail(rejection || Buffer.concat([...stdOut, ...stdErr]).toString('utf-8'));
          }
 
          if (concatStdErr) {

--- a/src/lib/tasks/branch.ts
+++ b/src/lib/tasks/branch.ts
@@ -58,7 +58,6 @@ export function deleteBranchesTask(branches: string[], forceDelete = false): Str
 
          done(error);
       },
-      concatStdErr: true,
    }
 }
 
@@ -76,7 +75,6 @@ export function deleteBranchTask(branch: string, forceDelete = false): StringTas
 
          throw new GitResponseError(task.parser(error, ''), error);
       },
-      concatStdErr: true,
    };
 
    return task;

--- a/src/lib/tasks/check-is-repo.ts
+++ b/src/lib/tasks/check-is-repo.ts
@@ -7,12 +7,12 @@ export enum CheckRepoActions {
    IS_REPO_ROOT = 'root',
 }
 
-const onError: StringTask<boolean>['onError'] = (exitCode, stdErr, done, fail) => {
-   if (exitCode === ExitCodes.UNCLEAN && isNotRepoMessage(stdErr)) {
-      return done('false');
+const onError: StringTask<boolean>['onError'] = ({exitCode}, error, done, fail) => {
+   if (exitCode === ExitCodes.UNCLEAN && isNotRepoMessage(error)) {
+      return done(Buffer.from('false'));
    }
 
-   fail(stdErr);
+   fail(error);
 }
 
 const parser: StringTask<boolean>['parser'] = (text) => {
@@ -64,6 +64,6 @@ export function checkIsBareRepoTask(): StringTask<boolean> {
 }
 
 
-function isNotRepoMessage(message: string): boolean {
-   return /(Not a git repository|Kein Git-Repository)/i.test(message);
+function isNotRepoMessage(error: Error): boolean {
+   return /(Not a git repository|Kein Git-Repository)/i.test(String(error));
 }

--- a/src/lib/tasks/init.ts
+++ b/src/lib/tasks/init.ts
@@ -16,7 +16,6 @@ export function initTask(bare = false, path: string, customArgs: string[]): Stri
 
    return {
       commands,
-      concatStdErr: false,
       format: 'utf-8',
       parser(text: string): InitResult {
          return parseInit(commands.includes('--bare'), path, text);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -67,19 +67,22 @@ export interface SimpleGitPluginConfig {
    /**
     * Configures the content of errors thrown by the `simple-git` instance for each task
     */
-   errors: {
+   errors: ((error: Buffer | Error | undefined, result: Omit<GitExecutorResult, 'rejection'>) => Buffer | Error | undefined) | {
 
       /**
-       * When an error occurs, configure which of the output streams should be included in
-       * the error message.
-       *
-       * Defaults to both stdOut and stdErr, but can be configured to just `stdErr` for full
-       * backward compatibility with older versions of `simple-git` by setting `stdOut: false`.
+       * By default the error plugin will pass through any error detected by
+       * any other plugin, when supplied as `true` allows this error plugin to rewrite errors as
        */
-      streams: {
-         stdOut?: boolean;
-         stdErr?: boolean;
-      }
+      overwrite?: boolean;
+
+      /**
+       * Determines whether the result should be treated as an error. By default tasks
+       * are deemed to have failed when there is a non-zero `exitCode` and there was
+       * some content sent to the `stdErr` stream.
+       */
+      isError? (result: Omit<GitExecutorResult, 'rejection'>): boolean;
+
+      errorMessage? (result: Omit<GitExecutorResult, 'rejection'>): Buffer | Error;
    };
 
    /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -67,23 +67,7 @@ export interface SimpleGitPluginConfig {
    /**
     * Configures the content of errors thrown by the `simple-git` instance for each task
     */
-   errors: ((error: Buffer | Error | undefined, result: Omit<GitExecutorResult, 'rejection'>) => Buffer | Error | undefined) | {
-
-      /**
-       * By default the error plugin will pass through any error detected by
-       * any other plugin, when supplied as `true` allows this error plugin to rewrite errors as
-       */
-      overwrite?: boolean;
-
-      /**
-       * Determines whether the result should be treated as an error. By default tasks
-       * are deemed to have failed when there is a non-zero `exitCode` and there was
-       * some content sent to the `stdErr` stream.
-       */
-      isError? (result: Omit<GitExecutorResult, 'rejection'>): boolean;
-
-      errorMessage? (result: Omit<GitExecutorResult, 'rejection'>): Buffer | Error;
-   };
+   errors(error: Buffer | Error | undefined, result: Omit<GitExecutorResult, 'rejection'>): Buffer | Error | undefined;
 
    /**
     * Handler to be called with progress events emitted through the progress plugin
@@ -115,5 +99,6 @@ export interface SimpleGitOptions extends Partial<SimpleGitPluginConfig> {
 }
 
 export type Maybe<T> = T | undefined;
+export type MaybeArray<T> = T | T[];
 
 export type Primitives = string | number | boolean;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -62,20 +62,53 @@ export interface GitExecutorResult {
    rejection: Maybe<Error>;
 }
 
+export interface SimpleGitPluginConfig {
+
+   /**
+    * Configures the content of errors thrown by the `simple-git` instance for each task
+    */
+   errors: {
+
+      /**
+       * When an error occurs, configure which of the output streams should be included in
+       * the error message.
+       *
+       * Defaults to both stdOut and stdErr, but can be configured to just `stdErr` for full
+       * backward compatibility with older versions of `simple-git` by setting `stdOut: false`.
+       */
+      streams: {
+         stdOut?: boolean;
+         stdErr?: boolean;
+      }
+   };
+
+   /**
+    * Handler to be called with progress events emitted through the progress plugin
+    */
+   progress(data: SimpleGitProgressEvent): void;
+
+   /**
+    * Configuration for the `timeoutPlugin`
+    */
+   timeout: {
+
+      /**
+       * The number of milliseconds to wait after spawning the process / receiving
+       * content on the stdOut/stdErr streams before forcibly closing the git process.
+       */
+      block: number;
+   };
+}
+
 /**
  * Optional configuration settings to be passed to the `simpleGit`
  * builder.
  */
-export interface SimpleGitOptions {
+export interface SimpleGitOptions extends Partial<SimpleGitPluginConfig> {
    baseDir: string;
    binary: string;
    maxConcurrentProcesses: number;
    config: string[];
-   timeout?: {
-      block: number;
-   };
-
-   progress?(data: SimpleGitProgressEvent): void;
 }
 
 export type Maybe<T> = T | undefined;

--- a/src/lib/types/tasks.ts
+++ b/src/lib/types/tasks.ts
@@ -1,3 +1,4 @@
+import { GitExecutorResult } from './index';
 import { EmptyTask } from '../tasks/task';
 
 export type TaskResponseFormat = Buffer | string;
@@ -17,10 +18,10 @@ export interface SimpleGitTaskConfiguration<RESPONSE, FORMAT, INPUT extends Task
    parser: TaskParser<INPUT, RESPONSE>;
 
    onError?: (
-      exitCode: number,
-      error: string,
-      done: (result: INPUT) => void,
-      fail: (error: string) => void,
+      result: GitExecutorResult,
+      error: Error,
+      done: (result: Buffer | Buffer[]) => void,
+      fail: (error: string | Error) => void,
    ) => void;
 }
 

--- a/src/lib/types/tasks.ts
+++ b/src/lib/types/tasks.ts
@@ -22,13 +22,6 @@ export interface SimpleGitTaskConfiguration<RESPONSE, FORMAT, INPUT extends Task
       done: (result: INPUT) => void,
       fail: (error: string) => void,
    ) => void;
-
-   /**
-    * @deprecated
-    * Use of `concatStdErr` is now deprecated, to be removed by v2.50.0 (or on upgrading to v3).
-    * Instead, use the `stdErr` argument supplied to the `parser`
-    */
-   concatStdErr?: boolean;
 }
 
 export type StringTask<R> = SimpleGitTaskConfiguration<R, 'utf-8', string>;

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -137,3 +137,7 @@ export function prefixedArray<T>(input: T[], prefix: T): T[] {
    }
    return output;
 }
+
+export function bufferToString (input: Buffer | Buffer[]): string {
+   return (Array.isArray(input) ? Buffer.concat(input) : input).toString('utf-8');
+}

--- a/test/unit/plugin.error.spec.ts
+++ b/test/unit/plugin.error.spec.ts
@@ -1,0 +1,92 @@
+import { promiseError } from '@kwsites/promise-result';
+import { SimpleGitOptions } from '../../src/lib/types';
+import { assertGitError, closeWithError, closeWithSuccess, newSimpleGit } from './__fixtures__';
+import { GitError } from '../../src/lib/errors/git-error';
+
+describe('errorDetectionPlugin', () => {
+
+   describe('function configuration', () => {
+
+      it('can throw with custom content', async () => {
+         const errors = jest.fn().mockReturnValue(Buffer.from('foo'));
+         const git = newSimpleGit({errors}).init();
+         await closeWithError('err');
+
+         assertGitError(await promiseError(git), 'foo');
+      });
+
+      it('can throw error when otherwise deemed ok', async () => {
+         const errors = jest.fn().mockReturnValue(new Error('FAIL'));
+         const git = newSimpleGit({errors}).init();
+         await closeWithSuccess('OK');
+
+         expect(errors).toHaveBeenCalledWith(undefined, {
+            exitCode: 0,
+            stdErr: [],
+            stdOut: [expect.any(Buffer)],
+         });
+         assertGitError(await promiseError(git), 'FAIL');
+      });
+
+      it('can ignore errors that would otherwise throw', async () => {
+         const errors = jest.fn();
+
+         const git = newSimpleGit({errors}).raw('foo');
+         await closeWithError('OUT', 100);
+
+         expect(errors).toHaveBeenCalledWith(expect.any(GitError), {
+            exitCode: 100,
+            stdOut: [],
+            stdErr: [expect.any(Buffer)],
+         });
+         expect(await promiseError(git)).toBeUndefined();
+      });
+   })
+
+
+   describe('object configuration', () => {
+
+      it('overwrites error with buffer', async () => {
+         const options: Partial<SimpleGitOptions> = {
+            errors: {
+               overwrite: true,
+               isError: jest.fn().mockReturnValue(true),
+               errorMessage: jest.fn().mockReturnValue(Buffer.from('anything'))
+            },
+         };
+         const git = newSimpleGit(options).init();
+         await closeWithError('err');
+
+         assertGitError(await promiseError(git), 'anything');
+      });
+
+      it('error with buffer', async () => {
+         const options: Partial<SimpleGitOptions> = {
+            errors: {
+               isError: jest.fn().mockReturnValue(true),
+               errorMessage: jest.fn().mockReturnValue(Buffer.from('anything'))
+            },
+         };
+         const git = newSimpleGit(options).init();
+         await closeWithSuccess('ok');
+
+         assertGitError(await promiseError(git), 'anything');
+      });
+
+      it('throw with error', async () => {
+         const options: Partial<SimpleGitOptions> = {
+            errors: {
+               overwrite: true,
+               errorMessage: jest.fn().mockReturnValue(Buffer.from('anything'))
+            },
+         };
+         const git = newSimpleGit(options).init();
+         await closeWithError('err');
+
+         assertGitError(await promiseError(git), 'anything');
+      });
+
+   });
+
+
+});


### PR DESCRIPTION
By default, `simple-git` will determine that a `git` task has resulted in an error when the process exit
code is anything other than `0` and there has been some data sent to the `stdErr` stream. Error handlers
will be passed the content of both `stdOut` and `stdErr` concatenated together. 

To change any of this behaviour, configure the `simple-git` with the `errors` plugin with a function to be
called after every task has been run and should return either `undefined` when the task is treated as
a success, or a `Buffer` or `Error` when the task should be treated as a failure.

When the default error handler (or any other plugin) has thrown an error, the first argument to the error
detection plugin is the original error. Either return that error directly to allow it to bubble up to the
task's error handlers, or implement your own error detection as below:

```typescript
import simpleGit from 'simple-git';
const git = simpleGit({
   errors(error, result) {
      // optionally pass through any errors reported before this plugin runs
      if (error) return error;
      // customise the `errorCode` values to treat as success
      if (result.errorCode === 0) {
         return;
      }
      // the default error messages include both stdOut and stdErr, but that
      // can be changed here, or completely replaced with some other content
      return Buffer.concat([...result.stdOut, ...result.stdErr]);
   }
})
```