### PR TITLE
feat: Support enabling / disabling `debug` logs programmatically.

### DIFF
--- a/docs/DEBUG-LOGGING-GUIDE.md
+++ b/docs/DEBUG-LOGGING-GUIDE.md
@@ -1,0 +1,63 @@
+
+# Debug Logging
+
+This library uses [debug](https://www.npmjs.com/package/debug) to handle logging,
+to enable logging, use either the environment variable:
+
+```
+"DEBUG=simple-git" node ./your-app.js 
+``` 
+
+Or explicitly enable logging using the `debug` library itself:
+
+```javascript
+const debug = require('debug');
+const simpleGit = require('simple-git');
+
+debug.enable('simple-git,simple-git:*');
+simpleGit().init().then(() => console.log('DONE'));
+``` 
+
+
+```typescript
+import debug from 'debug';
+import simpleGit from 'simple-git';
+
+debug.enable('simple-git,simple-git:*');
+simpleGit().init().then(() => console.log('DONE'));
+``` 
+
+## Verbose Logging Options
+
+If the regular logs aren't sufficient to find the source of your issue, enable one or more of the
+following for a more complete look at what the library is doing:
+
+- `DEBUG=simple-git` the least verbose logging, used as a high-level overview of what the library is doing
+- `DEBUG=simple-git:task:*` adds debug output for each task being run through the library
+- `DEBUG=simple-git:task:add:*` adds debug output for specific git commands, just replace the `add` with
+  the command you need to investigate. To output multiple just add them both to the environment
+  variable eg: `DEBUG=simple-git:task:add:*,simple-git:task:commit:*`
+- `DEBUG=simple-git:output:*` logs the raw data received from the git process on both `stdOut` and `stdErr`
+- `DEBUG=simple-git,simple-git:*` logs _everything_ 
+
+## Problems enabling logs programmatically 
+
+The programmatic method of enabling / disabling logs through the `debug` library should 'just work',
+but you may have issues when there are multiple versions of `debug` available in the dependency tree.
+The simplest way to resolve that is to use a `resolutions` override in the `package.json`.
+
+For example this `package.json` depends on an old version of `simple-git` but instead of allowing
+`simple-git` to use its own old version of `debug`, `npm` would use version `4.3.1` throughout.
+
+```json
+{
+   "name": "my-app",
+   "dependencies": {
+      "simple-git": "^2.21.0",
+      "debug": "^4.3.1"
+   },
+   "resolutions": {
+      "debug": "^4.3.1"
+   }
+}
+```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@kwsites/file-exists": "^1.1.1",
     "@kwsites/promise-deferred": "^1.1.1",
-    "debug": "^4.3.2"
+    "debug": "^4.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/readme.md
+++ b/readme.md
@@ -385,8 +385,8 @@ When upgrading to release 2.x from 1.x, see the [changelog](./CHANGELOG.md) for 
   [run in parallel](#concurrent--parallel-requests) without failures impacting one anther. Prior to this
   version, tasks called on the root `git` instance would be cancelled when another one failed.
 
-- 2.7.0 deprecates use of `.silent()` in favour of using the `debug` library - see [Enable Logging](#enable-logging)
- for further details.
+- 2.7.0 deprecates use of `.silent()` in favour of using the `debug` library - see the
+  [debug logging guide](docs/DEBUG-LOGGING-GUIDE.md) for further details.
 
 - 2.6.0 introduced `.then` and `.catch` as a way to chain a promise onto the current step of the chain.
 Importing from `simple-git/promise` instead of just `simple-git` is no longer required and is actively discouraged.
@@ -599,30 +599,15 @@ catch (err) {
 
 ### Enable logging
 
-This library uses [debug](https://www.npmjs.com/package/debug) to handle logging,
-to enable logging, use either the environment variable:
-
-```
-"DEBUG=simple-git" node ./your-app.js 
-``` 
-
-Or explicitly enable logging using the `debug` library itself:
-
-```javascript
-require('debug').enable('simple-git');
-``` 
+See the [debug logging guide](docs/DEBUG-LOGGING-GUIDE.md) for logging examples and how to
+make use of the [debug](https://www.npmjs.com/package/debug) library's programmatic interface
+in your application.
 
 ### Enable Verbose Logging
 
-If the regular logs aren't sufficient to find the source of your issue, enable one or more of the
-following for a more complete look at what the library is doing:
-
-- `DEBUG=simple-git:task:*` adds debug output for each task being run through the library  
-- `DEBUG=simple-git:task:add:*` adds debug output for specific git commands, just replace the `add` with
-   the command you need to investigate. To output multiple just add them both to the environment
-   variable eg: `DEBUG=simple-git:task:add:*,simple-git:task:commit:*`
-- `DEBUG=simple-git:output:*` logs the raw data received from the git process on both `stdOut` and `stdErr`
-- `DEBUG=simple-git,simple-git:*` logs _everything_ 
+See the [debug logging guide](docs/DEBUG-LOGGING-GUIDE.md#verbose-logging-options) for
+the full list of verbose logging options to use with the
+[debug](https://www.npmjs.com/package/debug) library.
 
 ### Every command returns ENOENT error message
 

--- a/test/unit/git-executor.spec.ts
+++ b/test/unit/git-executor.spec.ts
@@ -2,8 +2,6 @@ import { newSimpleGit, wait } from './__fixtures__';
 import { SimpleGit } from 'typings';
 import { mockChildProcessModule } from './__mocks__/mock-child-process';
 
-jest.mock('child_process', () => mockChildProcessModule);
-
 async function withStdOut () {
    await wait();
    mockChildProcessModule.$mostRecent().stdout.$emit('data', Buffer.from('some data'));

--- a/test/unit/logging.spec.ts
+++ b/test/unit/logging.spec.ts
@@ -1,7 +1,5 @@
+import debug from 'debug';
 import { closeWithError, closeWithSuccess, newSimpleGit } from './__fixtures__';
-import { mockChildProcessModule } from './__mocks__/mock-child-process';
-
-jest.mock('child_process', () => mockChildProcessModule);
 
 describe('logging', () => {
 
@@ -10,6 +8,17 @@ describe('logging', () => {
    beforeEach(() => {
       $debugEnvironmentVariable('*');
       $enabled(true);
+   });
+
+   it('creates a new debug logger for each simpleGit instance', async () => {
+      (debug as any).mockClear();
+      newSimpleGit();
+      const logsCreated = (debug as any).mock.calls.length;
+      expect(logsCreated).toBeGreaterThanOrEqual(1);
+
+      (debug as any).mockClear();
+      newSimpleGit();
+      expect(debug).toHaveBeenCalledTimes(logsCreated);
    });
 
    it('logs task errors to main log as well as the detailed log', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,10 +2067,10 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
 


### PR DESCRIPTION
Prior to this change, logging through the `debug` library had to be configured either by environment variable or by using the relevant apis in `debug` before requiring/importing `simple-git`.

Following this change, a script can call `debug.enable('simple-git:*`) at any point to ensure any `simple-git` instance created after that point logs accordingly.