### PR TITLE
feat: add scope when adding config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -236,8 +236,10 @@ For type details of the response for each of the tasks, please see the [TypeScri
 
 ## git config
 
-- `.addConfig(key, value, append = false)` add a local configuration property, when `append` is set to `true` the
-  configuration setting is appended to rather than set in the local config.
+- `.addConfig(key, value, append = false, scope = 'local')` add a local configuration property, when `append` is set to
+  `true` the configuration setting is appended to rather than overwritten in the local config. Use the `scope` argument
+  to pick where to save the new configuration setting (use the exported `GitConfigScope` enum, or equivalent string
+  values - `worktree | local | global | system`).
 - `.listConfig()` reads the current configuration and returns a [ConfigListSummary](./src/lib/responses/ConfigList.ts)
 
 ## git hash-object

--- a/src/git.js
+++ b/src/git.js
@@ -20,22 +20,17 @@ const {branchTask, branchLocalTask, deleteBranchesTask, deleteBranchTask} = requ
 const {checkIgnoreTask} = require('./lib/tasks/check-ignore');
 const {checkIsRepoTask} = require('./lib/tasks/check-is-repo');
 const {cloneTask, cloneMirrorTask} = require('./lib/tasks/clone');
-const {addConfigTask, listConfigTask} = require('./lib/tasks/config');
 const {cleanWithOptionsTask, isCleanOptionsArray} = require('./lib/tasks/clean');
 const {commitTask} = require('./lib/tasks/commit');
 const {diffSummaryTask} = require('./lib/tasks/diff');
 const {fetchTask} = require('./lib/tasks/fetch');
-const {hashObjectTask} = require('./lib/tasks/hash-object');
-const {initTask} = require('./lib/tasks/init');
 const {logTask, parseLogOptions} = require('./lib/tasks/log');
-const {mergeTask} = require('./lib/tasks/merge');
 const {moveTask} = require("./lib/tasks/move");
 const {pullTask} = require('./lib/tasks/pull');
 const {pushTagsTask} = require('./lib/tasks/push');
 const {addRemoteTask, getRemotesTask, listRemotesTask, remoteTask, removeRemoteTask} = require('./lib/tasks/remote');
 const {getResetMode, resetTask} = require('./lib/tasks/reset');
 const {stashListTask} = require('./lib/tasks/stash-list');
-const {statusTask} = require('./lib/tasks/status');
 const {addSubModuleTask, initSubModuleTask, subModuleTask, updateSubModuleTask} = require('./lib/tasks/sub-module');
 const {addAnnotatedTagTask, addTagTask, tagListTask} = require('./lib/tasks/tag');
 const {straightThroughBufferTask, straightThroughStringTask} = require('./lib/tasks/task');
@@ -374,25 +369,6 @@ Git.prototype.branchLocal = function (then) {
       branchLocalTask(),
       trailingFunctionArgument(arguments),
    );
-};
-
-/**
- * Add config to local git instance
- *
- * @param {string} key configuration key (e.g user.name)
- * @param {string} value for the given key (e.g your name)
- * @param {boolean} [append=false] optionally append the key/value pair (equivalent of passing `--add` option).
- * @param {Function} [then]
- */
-Git.prototype.addConfig = function (key, value, append, then) {
-   return this._runTask(
-      addConfigTask(key, value, typeof append === "boolean" ? append : false),
-      trailingFunctionArgument(arguments),
-   );
-};
-
-Git.prototype.listConfig = function () {
-   return this._runTask(listConfigTask(), trailingFunctionArgument(arguments));
 };
 
 /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,11 +5,13 @@ import { GitResponseError } from './errors/git-response-error';
 import { TaskConfigurationError } from './errors/task-configuration-error';
 import { CheckRepoActions } from './tasks/check-is-repo';
 import { CleanOptions } from './tasks/clean';
+import { GitConfigScope } from './tasks/config';
 import { ResetMode } from './tasks/reset';
 
 const api = {
    CheckRepoActions,
    CleanOptions,
+   GitConfigScope,
    GitConstructError,
    GitError,
    GitPluginError,

--- a/src/lib/simple-git-api.ts
+++ b/src/lib/simple-git-api.ts
@@ -1,6 +1,7 @@
 import { SimpleGitBase } from '../../typings';
 import { taskCallback } from './task-callback';
 import { changeWorkingDirectoryTask } from './tasks/change-working-directory';
+import config from './tasks/config';
 import { hashObjectTask } from './tasks/hash-object';
 import { initTask } from './tasks/init';
 import { mergeTask } from './tasks/merge';
@@ -15,7 +16,7 @@ export class SimpleGitApi implements SimpleGitBase {
    constructor(private _executor: SimpleGitExecutor) {
    }
 
-   private _runTask<T>(task: SimpleGitTask<T>, then?: SimpleGitTaskCallback<T>) {
+   protected _runTask<T>(task: SimpleGitTask<T>, then?: SimpleGitTaskCallback<T>) {
       const chain = this._executor.chain();
       const promise = chain.push(task);
 
@@ -119,3 +120,5 @@ export class SimpleGitApi implements SimpleGitBase {
       return this._runTask(statusTask(getTrailingOptions(arguments)), trailingFunctionArgument(arguments));
    }
 }
+
+Object.assign(SimpleGitApi.prototype, config());

--- a/src/lib/tasks/config.ts
+++ b/src/lib/tasks/config.ts
@@ -1,9 +1,25 @@
-import { ConfigListSummary } from '../../../typings';
-import { StringTask } from '../types';
+import { ConfigListSummary, SimpleGit } from '../../../typings';
 import { configListParser } from '../responses/ConfigList';
+import { SimpleGitApi } from '../simple-git-api';
+import { StringTask } from '../types';
+import { trailingFunctionArgument } from '../utils';
 
-export function addConfigTask(key: string, value: string, append = false): StringTask<string> {
-   const commands: string[] = ['config', '--local'];
+export enum GitConfigScope {
+   system = 'system',
+   global = 'global',
+   local = 'local',
+   worktree = 'worktree',
+}
+
+function asConfigScope(scope: GitConfigScope | unknown): GitConfigScope {
+   if (typeof scope === 'string' && GitConfigScope.hasOwnProperty(scope)) {
+      return scope as GitConfigScope;
+   }
+   return GitConfigScope.local;
+}
+
+function addConfigTask(key: string, value: string, append: boolean, scope: GitConfigScope): StringTask<string> {
+   const commands: string[] = ['config', `--${scope}`];
 
    if (append) {
       commands.push('--add');
@@ -20,7 +36,7 @@ export function addConfigTask(key: string, value: string, append = false): Strin
    }
 }
 
-export function listConfigTask(): StringTask<ConfigListSummary> {
+function listConfigTask(): StringTask<ConfigListSummary> {
    return {
       commands: ['config', '--list', '--show-origin', '--null'],
       format: 'utf-8',
@@ -28,4 +44,22 @@ export function listConfigTask(): StringTask<ConfigListSummary> {
          return configListParser(text);
       },
    }
+}
+
+export default function (): Pick<SimpleGit, 'addConfig' | 'listConfig'> {
+   return {
+      addConfig(this: SimpleGitApi, key: string, value: string, ...rest: unknown[]) {
+         return this._runTask(
+            addConfigTask(key, value, rest[0] === true, asConfigScope(rest[1])),
+            trailingFunctionArgument(arguments),
+         );
+      },
+
+      listConfig(this: SimpleGitApi) {
+         return this._runTask(
+            listConfigTask(),
+            trailingFunctionArgument(arguments),
+         );
+      },
+   };
 }

--- a/test/__fixtures__/setup-init.ts
+++ b/test/__fixtures__/setup-init.ts
@@ -4,8 +4,8 @@ import { SimpleGitTestContext } from './create-test-context';
 export const GIT_USER_NAME = 'Simple Git Tests';
 export const GIT_USER_EMAIL = 'tests@simple-git.dev';
 
-export async function setUpInit ({git}: SimpleGitTestContext, bare = false) {
-   await git.init(bare);
+export async function setUpInit ({git}: SimpleGitTestContext) {
+   await git.raw('-c', 'init.defaultbranch=master', 'init');
    await configureGitCommitter(git);
 }
 

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -1,5 +1,6 @@
 import { SimpleGit } from 'typings';
 import { assertExecutedCommands, closeWithSuccess, newSimpleGit } from './__fixtures__';
+import { GitConfigScope } from '../..';
 import { configListParser } from '../../src/lib/responses/ConfigList';
 
 describe('config list parser', () => {
@@ -72,5 +73,19 @@ describe('config', () => {
 
       closeWithSuccess();
    }));
+
+   it.each([
+      ['system', '--system'],
+      ['global', '--global'],
+      ['local', '--local'],
+      ['worktree', '--worktree'],
+      ['blah', '--local'],
+      [GitConfigScope.global, '--global'],
+   ])('allows custom scope scope: %s', async (scope, expected) => {
+      git.addConfig('key', 'value', false, scope as GitConfigScope);
+      await closeWithSuccess();
+
+      assertExecutedCommands('config', expected, 'key', 'value');
+   });
 
 });

--- a/typings/simple-git.d.ts
+++ b/typings/simple-git.d.ts
@@ -118,6 +118,8 @@ export interface SimpleGit extends SimpleGitBase {
     * Add config to local git instance for the specified `key` (eg: user.name) and value (eg: 'your name').
     * Set `append` to true to append to rather than overwrite the key
     */
+   addConfig(key: string, value: string, append?: boolean, scope?: 'system' | 'global' | 'local' | 'worktree', callback?: types.SimpleGitTaskCallback<string>): Response<string>;
+
    addConfig(key: string, value: string, append?: boolean, callback?: types.SimpleGitTaskCallback<string>): Response<string>;
 
    addConfig(key: string, value: string, callback?: types.SimpleGitTaskCallback<string>): Response<string>;

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -8,5 +8,6 @@ export {
 export { CheckRepoActions } from '../src/lib/tasks/check-is-repo';
 export { CleanOptions, CleanMode } from '../src/lib/tasks/clean';
 export { CloneOptions } from '../src/lib/tasks/clone';
+export { GitConfigScope } from '../src/lib/tasks/config';
 export { ApplyOptions } from '../src/lib/tasks/apply-patch';
 export { ResetOptions, ResetMode } from '../src/lib/tasks/reset';


### PR DESCRIPTION
feat: allow setting the scope of `git config add` to work on the `local`, `global` or `system` configuration.

```
git.addConfig('user.name', 'My Name', false, GitConfigScope.global)
```


