### PR TITLE
fix: Commit parsing should cater for file names with square brackets

### DIFF
--- a/src/lib/parsers/parse-commit.ts
+++ b/src/lib/parsers/parse-commit.ts
@@ -2,7 +2,7 @@ import { CommitResult } from '../../../typings';
 import { LineParser, parseStringResponse } from '../utils';
 
 const parsers: LineParser<CommitResult>[] = [
-   new LineParser(/\[([^\s]+)( \([^)]+\))? ([^\]]+)/, (result, [branch, root, commit]) => {
+   new LineParser(/^\[([^\s]+)( \([^)]+\))? ([^\]]+)/, (result, [branch, root, commit]) => {
       result.branch = branch;
       result.commit = commit;
       result.root = !!root;

--- a/test/unit/__fixtures__/responses/commit.ts
+++ b/test/unit/__fixtures__/responses/commit.ts
@@ -24,3 +24,11 @@ export function commitToRepoRoot ({message = 'Commit Message', hash = 'b13bdd8',
  create mode 100644 ${fileName}
 `;
 }
+
+export function commitToBranch ({message = 'Commit Message', hash = 'b13bdd8', fileName = 'file-name', branch = 'branch'} = {}) {
+   return `
+[${branch} ${hash}] ${message}
+ 1 file changed, 1 insertion(+)
+ create mode 100644 ${fileName}
+`;
+}

--- a/test/unit/commit.spec.ts
+++ b/test/unit/commit.spec.ts
@@ -3,6 +3,7 @@ import {
    closeWithSuccess,
    commitResultNoneStaged,
    commitResultSingleFile,
+   commitToBranch,
    commitToRepoRoot,
    like,
    newSimpleGit
@@ -134,6 +135,14 @@ describe('commit', () => {
             branch: 'master',
             commit: 'foo',
             root: true
+         }));
+      });
+
+      it('handles files with square brackets', () => {
+         const actual = parseCommitResult(commitToBranch({fileName: '[AB] CDE FGH.txt', branch: 'alpha'}));
+         expect(actual).toEqual(like({
+            branch: 'alpha',
+            root: false
          }));
       })
 


### PR DESCRIPTION
fix: Commit parsing should cater for file names with square brackets