### PR TITLE
fix: literal true and false to aid type assertions

### DIFF
--- a/test/unit/log.spec.ts
+++ b/test/unit/log.spec.ts
@@ -1,4 +1,4 @@
-import { ListLogSummary, SimpleGit } from 'typings';
+import { LogResult, SimpleGit } from 'typings';
 import {
    assertExecutedCommands,
    assertExecutedCommandsContains,
@@ -523,7 +523,7 @@ ${START_BOUNDARY}207601debebc170830f2921acf2b6b27034c3b1f::2016-01-03 15:50:58 +
 
    describe('deprecations', () => {
       it('supports ListLogSummary without generic type', async () => {
-         const summary: Promise<ListLogSummary> = git.log({from: 'from', to: 'to'});
+         const summary: Promise<LogResult> = git.log({from: 'from', to: 'to'});
          await closeWithSuccess();
 
          expect(summary).not.toBe(undefined);

--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -118,14 +118,14 @@ export interface DiffResultTextFile {
    changes: number;
    insertions: number;
    deletions: number;
-   binary: boolean;
+   binary: false;
 }
 
 export interface DiffResultBinaryFile {
    file: string;
    before: number;
    after: number;
-   binary: boolean;
+   binary: true;
 }
 
 export interface DiffResult {


### PR DESCRIPTION
fix: use literal `true` and `false` in `DiffResultTextFile | DiffResultBinaryFile` to aid type assertions.

Closes #657 