### PR TITLE
feat: `git.getConfig`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,11 @@ For type details of the response for each of the tasks, please see the [TypeScri
   `true` the configuration setting is appended to rather than overwritten in the local config. Use the `scope` argument
   to pick where to save the new configuration setting (use the exported `GitConfigScope` enum, or equivalent string
   values - `worktree | local | global | system`).
+  
+- `.getConfig(key)` get the value(s) for a named key as a [ConfigGetResult](typings/response.d.ts)
+- `.getConfig(key, scope)` get the value(s) for a named key as a [ConfigGetResult](typings/response.d.ts) but limit the
+  scope of the properties searched to a single specified scope (use the exported `GitConfigScope` enum, or equivalent
+  string values - `worktree | local | global | system`)
 
 - `.listConfig()` reads the current configuration and returns a [ConfigListSummary](./src/lib/responses/ConfigList.ts)
 - `.listConfig(scope: GitConfigScope)` as with `listConfig` but returns only those items in a specified scope (note that configuration values are overlaid on top of each other to build the config `git` will actually use - to resolve the configuration you are using use `(await listConfig()).all` without the scope argument)

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -134,27 +134,66 @@ custom@mydev.co\0`);
       assertExecutedCommands('config', '--list', '--show-origin', '--null', '--system');
    });
 
-   it('gets a single item', async () => {
-      const task = git.getConfig('foo');
-      await closeWithSuccess('response\n');
+   describe('getConfig', () => {
+      it('exposes all values split by scope', async () => {
+         const task = git.getConfig('some.prop');
+         await closeWithSuccess('file:.git/blah\0some.prop\nvalue\0file:.git/config\0some.prop\nvalue1\0file:.git/config\0some.prop\nvalue2\0');
+         const {scopes} = await task;
 
-      expect(await task).toBe('response');
-      assertExecutedCommands('config', '--get', 'foo');
+         expect(scopes).toEqual(new Map([
+            ['.git/blah', ['value']],
+            ['.git/config', ['value1', 'value2']],
+         ]))
+      });
+
+      it('ignores properties with mismatched key', async () => {
+         const task = git.getConfig('some.prop');
+         await closeWithSuccess('file:.git/blah\0other.prop\nvalue\0file:.git/config\0some.prop\nvalue1\0file:.git/config\0other.prop\nvalue2\0');
+         const {value, values, scopes} = await task;
+
+         expect(value).toBe('value1');
+         expect(values).toEqual(['value1']);
+         expect(scopes).toEqual(new Map([
+            ['.git/config', ['value1']],
+         ]))
+      });
+
+      it('gets a single item', async () => {
+         const task = git.getConfig('foo');
+         await closeWithSuccess(`file:/Users/me/.gitconfig\0foo
+bar\0file:.git/config\0foo
+baz\0`);
+
+         expect(await task).toEqual(like({
+            key: 'foo',
+            value: 'baz',
+            values: ['bar', 'baz'],
+            paths: ['/Users/me/.gitconfig', '.git/config'],
+         }));
+         assertExecutedCommands('config', '--null', '--show-origin', '--get-all', 'foo');
+      });
+
+      it('gets a single item in a specific scope', async () => {
+         const task = git.getConfig('user.email', 'local');
+         await closeWithSuccess(`file:.git/config\0user.email
+another@mydev.co\0file:.git/config\0user.email
+final@mydev.co\0`);
+
+         expect(await task).toEqual(like({
+            value: 'final@mydev.co',
+            values: ['another@mydev.co', 'final@mydev.co'],
+            paths: ['.git/config'],
+         }));
+         assertExecutedCommands('config', '--local', '--null', '--show-origin', '--get-all', 'user.email');
+      });
+
+      it('allows callbacks when getting a single item', async () => {
+         const callback = jest.fn();
+         git.getConfig('foo', GitConfigScope.system, callback);
+         await closeWithSuccess(`file:/Users/me/.gitconfig\0foo\nbar\0\n\n`);
+
+         expect(callback).toHaveBeenCalledWith(null, like({value: 'bar'}));
+      });
    });
 
-   it('gets a single item in a specific scope', async () => {
-      const task = git.getConfig('foo', 'local');
-      await closeWithSuccess('response\n');
-
-      expect(await task).toBe('response');
-      assertExecutedCommands('config', '--local', '--get', 'foo');
-   });
-
-   it('allows callbacks when getting a single item', async () => {
-      const callback = jest.fn();
-      git.getConfig('foo', 'local', callback);
-      await closeWithSuccess('response\n');
-
-      expect(callback).toHaveBeenCalledWith(null, 'response');
-   });
 });

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -134,4 +134,27 @@ custom@mydev.co\0`);
       assertExecutedCommands('config', '--list', '--show-origin', '--null', '--system');
    });
 
+   it('gets a single item', async () => {
+      const task = git.getConfig('foo');
+      await closeWithSuccess('response\n');
+
+      expect(await task).toBe('response');
+      assertExecutedCommands('config', '--get', 'foo');
+   });
+
+   it('gets a single item in a specific scope', async () => {
+      const task = git.getConfig('foo', 'local');
+      await closeWithSuccess('response\n');
+
+      expect(await task).toBe('response');
+      assertExecutedCommands('config', '--local', '--get', 'foo');
+   });
+
+   it('allows callbacks when getting a single item', async () => {
+      const callback = jest.fn();
+      git.getConfig('foo', 'local', callback);
+      await closeWithSuccess('response\n');
+
+      expect(callback).toHaveBeenCalledWith(null, 'response');
+   });
 });

--- a/typings/response.d.ts
+++ b/typings/response.d.ts
@@ -83,6 +83,28 @@ export interface CommitResult {
    };
 }
 
+/** Represents the response to using `git.getConfig` */
+export interface ConfigGetResult {
+   /** The key that was searched for */
+   key: string;
+
+   /** The single value seen by `git` for this key (equivalent to `git config --get key`) */
+   value: string | null;
+
+   /** All possible values for this key no matter the scope (equivalent to `git config --get-all key`) */
+   values: string[];
+
+   /** The file paths from which configuration was read */
+   paths: string[];
+
+   /**
+    * The full hierarchy of values the property can have had across the
+    * various scopes that were searched (keys in this Map are the strings
+    * also found in the `paths` array).
+    */
+   scopes: Map<string, string[]>;
+}
+
 /**
  * Represents the current git configuration, as defined by the output from `git log`
  */

--- a/typings/simple-git.d.ts
+++ b/typings/simple-git.d.ts
@@ -124,6 +124,8 @@ export interface SimpleGit extends SimpleGitBase {
 
    addConfig(key: string, value: string, callback?: types.SimpleGitTaskCallback<string>): Response<string>;
 
+   getConfig(key: string, scope?: 'system' | 'global' | 'local' | 'worktree', callback?: types.SimpleGitTaskCallback<string>): Response<string>;
+
    /**
     * Applies a patch to the repo
     */

--- a/typings/simple-git.d.ts
+++ b/typings/simple-git.d.ts
@@ -118,13 +118,11 @@ export interface SimpleGit extends SimpleGitBase {
     * Add config to local git instance for the specified `key` (eg: user.name) and value (eg: 'your name').
     * Set `append` to true to append to rather than overwrite the key
     */
-   addConfig(key: string, value: string, append?: boolean, scope?: 'system' | 'global' | 'local' | 'worktree', callback?: types.SimpleGitTaskCallback<string>): Response<string>;
+   addConfig(key: string, value: string, append?: boolean, scope?: keyof typeof types.GitConfigScope, callback?: types.SimpleGitTaskCallback<string>): Response<string>;
 
    addConfig(key: string, value: string, append?: boolean, callback?: types.SimpleGitTaskCallback<string>): Response<string>;
 
    addConfig(key: string, value: string, callback?: types.SimpleGitTaskCallback<string>): Response<string>;
-
-   getConfig(key: string, scope?: 'system' | 'global' | 'local' | 'worktree', callback?: types.SimpleGitTaskCallback<string>): Response<string>;
 
    /**
     * Applies a patch to the repo
@@ -136,7 +134,7 @@ export interface SimpleGit extends SimpleGitBase {
    /**
     * Configuration values visible to git in the current working directory
     */
-   listConfig(scope: types.GitConfigScope | string, callback?: types.SimpleGitTaskCallback<resp.ConfigListSummary>): Response<resp.ConfigListSummary>;
+   listConfig(scope: keyof typeof types.GitConfigScope, callback?: types.SimpleGitTaskCallback<resp.ConfigListSummary>): Response<resp.ConfigListSummary>;
 
    listConfig(callback?: types.SimpleGitTaskCallback<resp.ConfigListSummary>): Response<resp.ConfigListSummary>;
 
@@ -371,6 +369,13 @@ export interface SimpleGit extends SimpleGitBase {
    fetch(options?: types.TaskOptions, callback?: types.SimpleGitTaskCallback<resp.FetchResult>): Response<resp.FetchResult>;
 
    fetch(callback?: types.SimpleGitTaskCallback<resp.FetchResult>): Response<resp.FetchResult>;
+
+   /**
+    * Gets the current value of a configuration property by it key, optionally specify the scope in which
+    * to run the command (omit / set to `undefined` to check in the complete overlaid configuration visible
+    * to the `git` process).
+    */
+   getConfig(key: string, scope?: keyof typeof types.GitConfigScope, callback?: types.SimpleGitTaskCallback<string>): Response<resp.ConfigGetResult>;
 
    /**
     * Gets the currently available remotes, setting the optional verbose argument to true includes additional


### PR DESCRIPTION
`git.getConfig` add support for getting the current value of a git configuration setting based on its name.

```typescript
// read value from the combined settings git uses
expect(await git.getConfig('user.name')).toBe('My Name');

// read value from a specific scope
expect(await git.getConfig('user.name', 'local')).toBe('My Name In This Repo');
```