### PR TITLE
feat: Use author email field that respects mailmap

### DIFF
--- a/src/lib/tasks/log.ts
+++ b/src/lib/tasks/log.ts
@@ -93,7 +93,7 @@ export function parseLogOptions<T extends Options>(opt: LogOptions<T> = {}, cust
       refs: '%D',
       body: opt.multiLine ? '%B' : '%b',
       author_name: '%aN',
-      author_email: '%ae'
+      author_email: '%aE'
    };
 
    const [fields, formatStr] = prettyFormat(format, splitter);


### PR DESCRIPTION
Seems the author names is already using the same format, no reason email should not.
This will allow using the mailmap functionality of git that is currently not possible (without
a custom log format config).

Should not affect anyone not using mailmap as they will get the same email address

See: https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emaNem