### PR TITLE
fix: support progress events in locales other than Western European character sets.

### DIFF
--- a/src/lib/plugins/progress-monitor-plugin.ts
+++ b/src/lib/plugins/progress-monitor-plugin.ts
@@ -15,7 +15,7 @@ export function progressMonitorPlugin(progress: Exclude<SimpleGitOptions['progre
          }
 
          context.spawned.stderr?.on('data', (chunk: Buffer) => {
-            const message = /^([a-zA-Z ]+):\s*(\d+)% \((\d+)\/(\d+)\)/.exec(chunk.toString('utf8'));
+            const message = /^([\s\S]+?):\s*(\d+)% \((\d+)\/(\d+)\)/.exec(chunk.toString('utf8'));
             if (!message) {
                return;
             }

--- a/test/unit/plugins.spec.ts
+++ b/test/unit/plugins.spec.ts
@@ -46,6 +46,20 @@ describe('plugins', () => {
 
    describe('progress', () => {
 
+      it('caters for non ISO-8859-1 characters', async () => {
+         newSimpleGit({progress: fn}).raw('anything', '--progress');
+
+         await writeToStdErr(`Определение изменений: 90% (9/10)`);
+
+         expect(fn).toHaveBeenCalledWith({
+            method: 'anything',
+            progress: 90,
+            processed: 9,
+            stage: 'определение',
+            total: 10,
+         });
+      })
+
       it('emits progress events when counting objects', async () => {
          newSimpleGit({progress: fn}).raw('something', '--progress');
 


### PR DESCRIPTION
fix: support progress events in locales other than Western European character sets.

As identified in #579 - characters not recognised by the RegExp `/([a-zA-Z]+):/` cause the progress event handler to not recognise the message, change to the more flexible `/([\s\S]+):/`