### PR TITLE
fix: Add example for empty commit message in `git.commit()`

### DIFF
--- a/test/unit/commit.spec.ts
+++ b/test/unit/commit.spec.ts
@@ -21,6 +21,12 @@ describe('commit', () => {
    });
 
    describe('usage', () => {
+      it('empty commit', async () => {
+         git.commit([], {'--amend': null, '--no-edit': null});
+         await closeWithSuccess();
+         assertExecutedCommands('commit', '--amend', '--no-edit');
+      });
+
       it('single message, no files, no options and callback', async () => {
          const task = git.commit('message', callback);
          await closeWithSuccess();


### PR DESCRIPTION
To use `git.commit()` without any `-m` messages in the generated command, use an empty array for the `messages` argument:

```typescript
// an empty array is permitted in place of zero message string
const messages: string[] = [];

// or other selection of options as required for your purposes
const options: TaskOptions = { '--allow-empty': null };

git.commit(messages, options); 
```

Closes #694 