### PR TITLE
fix: allow branches without labels

### DIFF
--- a/src/lib/parsers/parse-branch.ts
+++ b/src/lib/parsers/parse-branch.ts
@@ -10,7 +10,7 @@ const parsers: LineParser<BranchSummaryResult>[] = [
          name, commit, label
       );
    }),
-   new LineParser(/^(\*\s)?(\S+)\s+([a-z0-9]+)\s(.*)$/s, (result, [current, name, commit, label]) => {
+   new LineParser(/^(\*\s)?(\S+)\s+([a-z0-9]+)\s?(.*)$/s, (result, [current, name, commit, label]) => {
       result.push(
          !!current,
          false,

--- a/test/unit/branch.spec.ts
+++ b/test/unit/branch.spec.ts
@@ -209,6 +209,38 @@ describe('branch', () => {
             all: ['2b2dba2', 'cflynn07-add-git-ignore', 'master'],
          }));
       });
+
+      it('branches without labels', async () => {
+         const actual = parseBranchSummary(`
+* stable                f8cc2bc
+  remotes/origin/stable f8cc2bd
+  dev                   f8cc2be wip
+         `);
+         expect(actual).toEqual(like({
+            current: 'stable',
+            all: ['stable', 'remotes/origin/stable', 'dev'],
+            branches: {
+               stable: {
+                  commit: 'f8cc2bc',
+                  current: true,
+                  label: '',
+                  name: 'stable',
+               },
+               ['remotes/origin/stable']: {
+                  commit: 'f8cc2bd',
+                  current: false,
+                  label: '',
+                  name: 'remotes/origin/stable',
+               },
+               dev: {
+                  commit: 'f8cc2be',
+                  current: false,
+                  label: 'wip',
+                  name: 'dev',
+               },
+            }
+         }));
+      });
    });
 
    describe('usage', () => {


### PR DESCRIPTION
In Github Actions, git is not showing the commits (label) for branches when running `git branch -v -a` and the parsing was failing, so the current branch was being set to an empty string

git version 2.32.0

![image](https://user-images.githubusercontent.com/1891977/148278889-25c04f4c-3bb3-43f7-8c03-abd6cb1382aa.png)
