### PR TITLE
fix: Backward compatible imports

### DIFF
--- a/simple-git/package.json
+++ b/simple-git/package.json
@@ -44,6 +44,9 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./promise": {
+      "require": "./promise.js"
     }
   },
   "types": "./typings/index.d.ts",
@@ -75,6 +78,9 @@
       ".": {
         "import": "./esm/index.js",
         "require": "./cjs/index.js"
+      },
+      "./promise": {
+        "require": "./promise.js"
       }
     }
   }


### PR DESCRIPTION
For backward compatibility - permit loading `simple-git/promise` with deprecation notice until mid-2022.