### PR TITLE
fix: support parsing empty responses

### DIFF
--- a/simple-git/src/lib/responses/PullSummary.ts
+++ b/simple-git/src/lib/responses/PullSummary.ts
@@ -1,4 +1,4 @@
-import { PullDetailFileChanges, PullDetailSummary, PullResult } from '../../../typings';
+import { PullDetailFileChanges, PullDetailSummary, PullFailedResult, PullResult } from '../../../typings';
 
 export class PullSummary implements PullResult {
    public remoteMessages = {
@@ -16,4 +16,20 @@ export class PullSummary implements PullResult {
    };
 }
 
+export class PullFailedSummary implements PullFailedResult {
+   remote = '';
+   hash = {
+      local: '',
+      remote: '',
+   };
+   branch = {
+      local: '',
+      remote: '',
+   };
+   message = '';
+
+   toString() {
+      return this.message;
+   }
+}
 

--- a/simple-git/src/lib/tasks/pull.ts
+++ b/simple-git/src/lib/tasks/pull.ts
@@ -1,6 +1,8 @@
 import { PullResult } from '../../../typings';
-import { parsePullResult } from '../parsers/parse-pull';
+import { GitResponseError } from '../errors/git-response-error';
+import { parsePullErrorResult, parsePullResult } from '../parsers/parse-pull';
 import { Maybe, StringTask } from '../types';
+import { bufferToString } from '../utils';
 
 export function pullTask(remote: Maybe<string>, branch: Maybe<string>, customArgs: string[]): StringTask<PullResult> {
    const commands: string[] = ['pull', ...customArgs];
@@ -13,6 +15,14 @@ export function pullTask(remote: Maybe<string>, branch: Maybe<string>, customArg
       format: 'utf-8',
       parser(stdOut, stdErr): PullResult {
          return parsePullResult(stdOut, stdErr);
+      },
+      onError(result, _error, _done, fail) {
+         const pullError = parsePullErrorResult(bufferToString(result.stdOut), bufferToString(result.stdErr));
+         if (pullError) {
+            return fail(new GitResponseError(pullError));
+         }
+
+         fail(_error);
       }
    }
 }

--- a/simple-git/src/lib/utils/util.ts
+++ b/simple-git/src/lib/utils/util.ts
@@ -55,7 +55,7 @@ function isArrayLike(input: any): input is ArrayLike {
    return !!(input && typeof input.length === 'number');
 }
 
-export function toLinesWithContent(input: string, trimmed = true, separator = '\n'): string[] {
+export function toLinesWithContent(input = '', trimmed = true, separator = '\n'): string[] {
    return input.split(separator)
       .reduce((output, line) => {
          const lineContent = trimmed ? line.trim() : line;

--- a/simple-git/test/__fixtures__/setup-init.ts
+++ b/simple-git/test/__fixtures__/setup-init.ts
@@ -1,15 +1,14 @@
-import { SimpleGit } from '../../typings';
 import { SimpleGitTestContext } from './create-test-context';
 
 export const GIT_USER_NAME = 'Simple Git Tests';
 export const GIT_USER_EMAIL = 'tests@simple-git.dev';
 
-export async function setUpInit ({git}: Pick<SimpleGitTestContext, 'git'>) {
+export async function setUpInit({git}: Pick<SimpleGitTestContext, 'git'>) {
    await git.raw('-c', 'init.defaultbranch=master', 'init');
-   await configureGitCommitter(git);
+   await setUpGitUser({git});
 }
 
-async function configureGitCommitter (git: SimpleGit, name = GIT_USER_NAME, email = GIT_USER_EMAIL) {
+export async function setUpGitUser({git}: Pick<SimpleGitTestContext, 'git'>, name = GIT_USER_NAME, email = GIT_USER_EMAIL) {
    await git.addConfig('user.name', name);
    await git.addConfig('user.email', email);
 }

--- a/simple-git/test/__fixtures__/setup-init.ts
+++ b/simple-git/test/__fixtures__/setup-init.ts
@@ -4,7 +4,7 @@ import { SimpleGitTestContext } from './create-test-context';
 export const GIT_USER_NAME = 'Simple Git Tests';
 export const GIT_USER_EMAIL = 'tests@simple-git.dev';
 
-export async function setUpInit ({git}: SimpleGitTestContext) {
+export async function setUpInit ({git}: Pick<SimpleGitTestContext, 'git'>) {
    await git.raw('-c', 'init.defaultbranch=master', 'init');
    await configureGitCommitter(git);
 }

--- a/simple-git/test/__fixtures__/setup-init.ts
+++ b/simple-git/test/__fixtures__/setup-init.ts
@@ -1,3 +1,4 @@
+import { SimpleGit } from '../../typings';
 import { SimpleGitTestContext } from './create-test-context';
 
 export const GIT_USER_NAME = 'Simple Git Tests';
@@ -5,10 +6,10 @@ export const GIT_USER_EMAIL = 'tests@simple-git.dev';
 
 export async function setUpInit({git}: Pick<SimpleGitTestContext, 'git'>) {
    await git.raw('-c', 'init.defaultbranch=master', 'init');
-   await setUpGitUser({git});
+   await configureGitCommitter(git);
 }
 
-export async function setUpGitUser({git}: Pick<SimpleGitTestContext, 'git'>, name = GIT_USER_NAME, email = GIT_USER_EMAIL) {
+async function configureGitCommitter (git: SimpleGit, name = GIT_USER_NAME, email = GIT_USER_EMAIL) {
    await git.addConfig('user.name', name);
    await git.addConfig('user.email', email);
 }

--- a/simple-git/test/integration/pull-fails-ff.spec.ts
+++ b/simple-git/test/integration/pull-fails-ff.spec.ts
@@ -1,6 +1,6 @@
 import { promiseError } from '@kwsites/promise-result';
 import { GitResponseError, PullFailedResult } from '../../typings';
-import { createTestContext, like, newSimpleGit, SimpleGitTestContext } from '../__fixtures__';
+import { createTestContext, like, newSimpleGit, setUpInit, SimpleGitTestContext } from '../__fixtures__';
 
 describe('pull --ff-only', () => {
    let context: SimpleGitTestContext;
@@ -8,7 +8,10 @@ describe('pull --ff-only', () => {
    beforeEach(async () => context = await createTestContext());
    beforeEach(async () => {
       const upstream = await context.dir('upstream');
+      const local = context.path('local');
       await context.file(['upstream', 'file']);
+
+      await setUpInit({git: newSimpleGit(upstream)});
 
       // make the remote
       await newSimpleGit(upstream)
@@ -17,7 +20,8 @@ describe('pull --ff-only', () => {
          .commit('first');
 
       // take a clone of the remote
-      await newSimpleGit(context.root).clone(upstream, 'local');
+      await newSimpleGit(context.root).clone(upstream, local);
+      await setUpInit({git: newSimpleGit(local)});
    });
 
    async function givenRemoteFileChanged() {

--- a/simple-git/test/integration/pull-fails-ff.spec.ts
+++ b/simple-git/test/integration/pull-fails-ff.spec.ts
@@ -1,6 +1,6 @@
 import { promiseError } from '@kwsites/promise-result';
 import { GitResponseError, PullFailedResult } from '../../typings';
-import { createTestContext, like, newSimpleGit, setUpInit, SimpleGitTestContext } from '../__fixtures__';
+import { createTestContext, like, newSimpleGit, setUpGitUser, setUpInit, SimpleGitTestContext } from '../__fixtures__';
 
 describe('pull --ff-only', () => {
    let context: SimpleGitTestContext;
@@ -11,18 +11,30 @@ describe('pull --ff-only', () => {
       const local = context.path('local');
       await context.file(['upstream', 'file']);
 
-      await setUpInit({git: newSimpleGit(upstream)});
-
-      // make the remote
-      await newSimpleGit(upstream)
-         .init()
-         .add('.')
-         .commit('first');
-
-      // take a clone of the remote
-      await newSimpleGit(context.root).clone(upstream, local);
-      await setUpInit({git: newSimpleGit(local)});
+      await givenRemote(upstream);
+      await givenLocal(upstream, local);
    });
+
+   async function givenLocal(upstream: string, local: string) {
+      console.log('givenLocal: cloning')
+      await newSimpleGit(context.root).clone(upstream, local);
+
+      console.log('givenLocal: setUpGitUser')
+      await setUpGitUser({git: newSimpleGit(local)});
+   }
+
+   async function givenRemote(upstream: string) {
+      const git = newSimpleGit(upstream);
+
+      console.log('givenRemote: setUpInit');
+      await setUpInit({git});
+
+      console.log('givenRemote: add');
+      await git.add('.');
+
+      console.log('givenRemote: commit');
+      await git.commit('first');
+   }
 
    async function givenRemoteFileChanged() {
       await context.file(['upstream', 'file'], 'new remote file content');

--- a/simple-git/test/integration/pull-fails-ff.spec.ts
+++ b/simple-git/test/integration/pull-fails-ff.spec.ts
@@ -1,6 +1,6 @@
 import { promiseError } from '@kwsites/promise-result';
 import { GitResponseError, PullFailedResult } from '../../typings';
-import { createTestContext, like, newSimpleGit, setUpGitUser, setUpInit, SimpleGitTestContext } from '../__fixtures__';
+import { createTestContext, like, newSimpleGit, setUpInit, SimpleGitTestContext } from '../__fixtures__';
 
 describe('pull --ff-only', () => {
    let context: SimpleGitTestContext;
@@ -16,23 +16,14 @@ describe('pull --ff-only', () => {
    });
 
    async function givenLocal(upstream: string, local: string) {
-      console.log('givenLocal: cloning')
       await newSimpleGit(context.root).clone(upstream, local);
-
-      console.log('givenLocal: setUpGitUser')
-      await setUpGitUser({git: newSimpleGit(local)});
+      await setUpInit({git: newSimpleGit(local)});
    }
 
    async function givenRemote(upstream: string) {
       const git = newSimpleGit(upstream);
-
-      console.log('givenRemote: setUpInit');
       await setUpInit({git});
-
-      console.log('givenRemote: add');
       await git.add('.');
-
-      console.log('givenRemote: commit');
       await git.commit('first');
    }
 

--- a/simple-git/test/integration/pull-fails-ff.spec.ts
+++ b/simple-git/test/integration/pull-fails-ff.spec.ts
@@ -1,0 +1,80 @@
+import { promiseError } from '@kwsites/promise-result';
+import { GitResponseError, PullFailedResult } from '../../typings';
+import { createTestContext, like, newSimpleGit, SimpleGitTestContext } from '../__fixtures__';
+
+describe('pull --ff-only', () => {
+   let context: SimpleGitTestContext;
+
+   beforeEach(async () => context = await createTestContext());
+   beforeEach(async () => {
+      const upstream = await context.dir('upstream');
+      await context.file(['upstream', 'file']);
+
+      // make the remote
+      await newSimpleGit(upstream)
+         .init()
+         .add('.')
+         .commit('first');
+
+      // take a clone of the remote
+      await newSimpleGit(context.root).clone(upstream, 'local');
+   });
+
+   async function givenRemoteFileChanged() {
+      await context.file(['upstream', 'file'], 'new remote file content');
+      await newSimpleGit(context.path('upstream')).add('.').commit('remote updated');
+   }
+
+   async function givenLocalFileChanged() {
+      await context.file(['local', 'file'], 'new local file content');
+      await newSimpleGit(context.path('local')).add('.').commit('local updated');
+   }
+
+   it('allows fast-forward when there are no changes local or remote', async () => {
+      const git = newSimpleGit(context.path('local'));
+      const result = await git.pull(['--ff-only']);
+
+      expect(result.files).toEqual([]);
+   });
+
+   it('allows fast-forward when there are some remote but no local changes', async () => {
+      await givenRemoteFileChanged();
+
+      const git = newSimpleGit(context.path('local'));
+      const result = await git.pull(['--ff-only']);
+
+      expect(result.files).toEqual(['file']);
+   });
+
+   it('allows fast-forward when there are no remote but some local changes', async () => {
+      await givenLocalFileChanged();
+
+      const git = newSimpleGit(context.path('local'));
+      const result = await git.pull(['--ff-only']);
+
+      expect(result.files).toEqual([]);
+   });
+
+   it('fails fast-forward when there are both remote and local changes', async () => {
+      await givenLocalFileChanged();
+      await givenRemoteFileChanged();
+
+      const git = newSimpleGit(context.path('local'));
+      const err = await promiseError<GitResponseError<PullFailedResult>>(git.pull(['--ff-only']));
+
+      expect(err?.git.message).toMatch('Not possible to fast-forward, aborting');
+      expect(err?.git).toEqual(like({
+         remote: context.path('upstream'),
+         hash: {
+            local: expect.any(String),
+            remote: expect.any(String),
+         },
+         branch: {
+            local: expect.any(String),
+            remote: expect.any(String),
+         },
+         message: String(err?.git),
+      }))
+   });
+
+});

--- a/simple-git/test/unit/utils.spec.ts
+++ b/simple-git/test/unit/utils.spec.ts
@@ -60,6 +60,13 @@ describe('utils', () => {
 
    describe('content', () => {
 
+      it('caters for empty values', () => {
+         expect(toLinesWithContent()).toEqual([]);
+         expect(toLinesWithContent(undefined, false)).toEqual([]);
+         expect(toLinesWithContent('')).toEqual([]);
+         expect(toLinesWithContent('', false)).toEqual([]);
+      });
+
       it('filters lines with content', () => {
          expect(toLinesWithContent(' \n content \n\n')).toEqual(['content']);
          expect(toLinesWithContent(' \n content \n\n', false)).toEqual([' ', ' content ']);

--- a/simple-git/typings/response.d.ts
+++ b/simple-git/typings/response.d.ts
@@ -257,6 +257,23 @@ export interface PullResult extends PullDetail, RemoteMessageResult {
 }
 
 /**
+ * Wrapped with the `GitResponseError` as the exception thrown from a `git.pull` task
+ * to provide additional detail as to what failed.
+ */
+export interface PullFailedResult {
+   remote: string,
+   hash: {
+      local: string;
+      remote: string;
+   },
+   branch: {
+      local: string;
+      remote: string;
+   },
+   message: string;
+}
+
+/**
  * Represents file name changes in a StatusResult
  */
 export interface StatusResultRenamed {

--- a/simple-git/typings/simple-git.d.ts
+++ b/simple-git/typings/simple-git.d.ts
@@ -442,7 +442,8 @@ export interface SimpleGit extends SimpleGitBase {
    mv(from: string | string[], to: string, callback?: types.SimpleGitTaskCallback<resp.MoveSummary>): Response<resp.MoveSummary>;
 
    /**
-    * Fetch from and integrate with another repository or a local branch.
+    * Fetch from and integrate with another repository or a local branch. In the case that the `git pull` fails with a
+    * recognised fatal error, the exception thrown by this function will be a `GitResponseError<PullFailedResult>`.
     */
    pull(remote?: string, branch?: string, options?: types.TaskOptions, callback?: types.SimpleGitTaskCallback<resp.PullResult>): Response<resp.PullResult>;
 


### PR DESCRIPTION
- parsers should treat `undefined` in either `stdout` or `stderr` the same as an empty string