### PR TITLE
feat: optionally include ignored files in `StatusResult`

### DIFF
--- a/simple-git/src/lib/responses/StatusSummary.ts
+++ b/simple-git/src/lib/responses/StatusSummary.ts
@@ -9,6 +9,7 @@ export class StatusSummary implements StatusResult {
    public conflicted = [];
    public created = [];
    public deleted = [];
+   public ignored = undefined;
    public modified = [];
    public renamed = [];
    public files = [];
@@ -81,6 +82,9 @@ const parsers: Map<string, StatusLineParser> = new Map([
       append(result.renamed, renamed);
       append(result.modified, renamed.to);
    }),
+   parser(PorcelainFileStatus.IGNORED, PorcelainFileStatus.IGNORED, (_result, _file) => {
+      append((_result.ignored = _result.ignored || []), _file);
+   }),
 
    parser(PorcelainFileStatus.UNTRACKED, PorcelainFileStatus.UNTRACKED, (result, file) => append(result.not_added, file)),
 
@@ -145,7 +149,7 @@ function splitLine(result: StatusResult, lineStr: string) {
          handler(result, path);
       }
 
-      if (raw !== '##') {
+      if (raw !== '##' && raw !== '!!') {
          result.files.push(new FileStatusSummary(path, index, workingDir));
       }
    }

--- a/simple-git/test/unit/__fixtures__/responses/status.ts
+++ b/simple-git/test/unit/__fixtures__/responses/status.ts
@@ -20,6 +20,10 @@ export function stagedModified(file = 'staged-modified.ext') {
    return `M  ${file}`;
 }
 
+export function stagedIgnored(file = 'ignored.ext') {
+   return `!! ${file}`;
+}
+
 export function statusResponse(branch = 'main', ...files: Array<string | (() => string)>) {
    const stdOut: string[] = [
       `## ${branch}`,

--- a/simple-git/test/unit/status.spec.ts
+++ b/simple-git/test/unit/status.spec.ts
@@ -8,6 +8,7 @@ import {
    newSimpleGit,
    newSimpleGitP,
    stagedDeleted,
+   stagedIgnored,
    stagedModified,
    stagedRenamed,
    stagedRenamedWithModifications,
@@ -142,7 +143,15 @@ describe('status', () => {
                }
             ],
          }))
-      })
+      });
+
+      it('Handles ignored files', () => {
+         expect(parseStatusSummary(statusResponse('main', stagedIgnored).stdOut)).toEqual(like({
+            ...empty,
+            ignored: ['ignored.ext'],
+            files: [],
+         }));
+      });
 
       it('Handles malformatted rename', () => {
          expect(parseStatusSummary(statusResponse('main', 'R  file.ext').stdOut)).toEqual(like({

--- a/simple-git/typings/response.d.ts
+++ b/simple-git/typings/response.d.ts
@@ -308,6 +308,15 @@ export interface StatusResult {
    conflicted: string[];
    created: string[];
    deleted: string[];
+
+   /**
+    * Ignored files are not listed by default, add `--ignored` to the task options in order to see
+    * this array of ignored files/paths.
+    *
+    * Note: ignored files will not be added to the `files` array, and will not be included in the
+    * `isClean()` calculation.
+    */
+   ignored?: string[];
    modified: string[];
    renamed: StatusResultRenamed[];
    staged: string[];


### PR DESCRIPTION
- When `git.status` is called with the `--ignored` flag, the `StatusResult` response will include an extra `ignored: string[]` property of ignored paths.

Closes #718