### PR TITLE
chore: add repository metadata to package.json

### DIFF
--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -9,5 +9,10 @@
     "@babel/preset-typescript": "^7.12.7",
     "babel-jest": "^27.4.5",
     "babel-plugin-module-resolver": "^4.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/steveukx/git-js.git",
+    "directory": "packages/babel-config"
   }
 }

--- a/packages/test-es-module-consumer/package.json
+++ b/packages/test-es-module-consumer/package.json
@@ -8,5 +8,10 @@
   },
   "dependencies": {
     "simple-git": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/steveukx/git-js.git",
+    "directory": "packages/test-es-module-consumer"
   }
 }

--- a/packages/test-javascript-consumer/package.json
+++ b/packages/test-javascript-consumer/package.json
@@ -7,5 +7,10 @@
   },
   "dependencies": {
     "simple-git": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/steveukx/git-js.git",
+    "directory": "packages/test-javascript-consumer"
   }
 }

--- a/packages/test-typescript-consumer/package.json
+++ b/packages/test-typescript-consumer/package.json
@@ -18,5 +18,10 @@
   "dependencies": {
     "@simple-git/babel-config": "^1.0.0",
     "simple-git": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/steveukx/git-js.git",
+    "directory": "packages/test-typescript-consumer"
   }
 }

--- a/simple-git/package.json
+++ b/simple-git/package.json
@@ -37,7 +37,12 @@
     "vcs"
   ],
   "license": "MIT",
-  "repository": "git://github.com/steveukx/git-js.git",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/steveukx/git-js.git",
+    "directory": "simple-git"
+  },
   "main": "src/index.js",
   "module": "dist/esm/index.js",
   "exports": {


### PR DESCRIPTION
## Changes:

- Add repository metadata to `package.json` file(s)

## Context:

Renovate bot cannot find the correct changelogs for the `simple-git` package.
I _think_ this is because the repository was recently changed to a monorepo, and npm no longer knows where the `package.json` file(s) are located.

Example of a PR with no changelogs: https://github.com/renovatebot/renovate/pull/13705

## npm documentation on monorepo setup

Relevant quote from npm 8 docs: [^npm-docs]

> If the `package.json` for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
>
>
> ```json
> {
>   "repository": {
>     "type": "git",
>     "url": "https://github.com/facebook/react.git",
>     "directory": "packages/react-dom"
>   }
> }
> ```

I'm not sure if _all of these files_ need this change, maybe only the `simple-git/package.json` needs to have the metadata.

[^npm-docs]: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository