### PR TITLE
feat: Support destructuring in `StatusSummary`.

### DIFF
--- a/simple-git/src/lib/responses/StatusSummary.ts
+++ b/simple-git/src/lib/responses/StatusSummary.ts
@@ -20,7 +20,7 @@ export class StatusSummary implements StatusResult {
    public tracking = null;
    public detached = false;
 
-   public isClean(): boolean {
+   public isClean = () => {
       return !this.files.length;
    }
 }

--- a/simple-git/test/unit/status.spec.ts
+++ b/simple-git/test/unit/status.spec.ts
@@ -290,6 +290,11 @@ R  src/a.txt -> src/c.txt
          expect(parseStatusSummary(`${type} file-name.foo`).isClean()).toBe(false);
       });
 
+      it('allows isClean to be destructured', () => {
+         const { isClean } = parseStatusSummary('\n');
+         expect(isClean()).toBe(true);
+      });
+
       it('reports empty response as a clean branch', () => {
          const statusSummary = parseStatusSummary('\n');
 


### PR DESCRIPTION
This change enables calling the `isClean` method from `git.status` without the `StatusSummary` context (ie: when destructured):

```typescript
const { isClean } = await simpleGit().status();
expect( isClean() ).toBe( true );
```