### PR TITLE
Feat/commit upgrade

### DIFF
--- a/.changeset/long-squids-shop.md
+++ b/.changeset/long-squids-shop.md
@@ -2,4 +2,4 @@
 "simple-git": minor
 ---
 
-Show full commit hash in a CommitResult
+Show full commit hash in a `CommitResult`, prior to this change `git.commit` resulted in a partial hash in the `commit` property, following this change the `commit` property contains a full hash.

--- a/.changeset/long-squids-shop.md
+++ b/.changeset/long-squids-shop.md
@@ -1,0 +1,5 @@
+---
+"simple-git": minor
+---
+
+Show full commit hash in a CommitResult

--- a/simple-git/src/git.js
+++ b/simple-git/src/git.js
@@ -141,35 +141,6 @@ Git.prototype.checkoutLatestTag = function (then) {
 };
 
 /**
- * Commits changes in the current working directory - when specific file paths are supplied, only changes on those
- * files will be committed.
- *
- * @param {string|string[]} message
- * @param {string|string[]} [files]
- * @param {Object} [options]
- * @param {Function} [then]
- */
-Git.prototype.commit = function (message, files, options, then) {
-   const next = trailingFunctionArgument(arguments);
-
-   if (!filterStringOrStringArray(message)) {
-      return this._runTask(
-         configurationErrorTask('git.commit: requires the commit message to be supplied as a string/string[]'),
-         next,
-      );
-   }
-
-   return this._runTask(
-      commitTask(
-         asArray(message),
-         asArray(filterType(files, filterStringOrStringArray, [])),
-         [...filterType(options, filterArray, []), ...getTrailingOptions(arguments, 0, true)]
-      ),
-      next
-   );
-};
-
-/**
  * Pull the updated contents of the current repo
  */
 Git.prototype.pull = function (remote, branch, options, then) {

--- a/simple-git/src/lib/runners/git-executor.ts
+++ b/simple-git/src/lib/runners/git-executor.ts
@@ -1,5 +1,5 @@
-import { PluginStore } from '../plugins';
-import { GitExecutorEnv, outputHandler, SimpleGitExecutor, SimpleGitTask } from '../types';
+import type { PluginStore } from '../plugins';
+import type { GitExecutorEnv, outputHandler, SimpleGitExecutor, SimpleGitTask } from '../types';
 
 import { GitExecutorChain } from './git-executor-chain';
 import { Scheduler } from './scheduler';

--- a/simple-git/src/lib/simple-git-api.ts
+++ b/simple-git/src/lib/simple-git-api.ts
@@ -1,6 +1,7 @@
 import { SimpleGitBase } from '../../typings';
 import { taskCallback } from './task-callback';
 import { changeWorkingDirectoryTask } from './tasks/change-working-directory';
+import commit from './tasks/commit';
 import config from './tasks/config';
 import grep from './tasks/grep';
 import { hashObjectTask } from './tasks/hash-object';
@@ -123,4 +124,4 @@ export class SimpleGitApi implements SimpleGitBase {
    }
 }
 
-Object.assign(SimpleGitApi.prototype, config(), grep(), log());
+Object.assign(SimpleGitApi.prototype, commit(), config(), grep(), log());

--- a/simple-git/src/lib/tasks/commit.ts
+++ b/simple-git/src/lib/tasks/commit.ts
@@ -1,20 +1,53 @@
-import { CommitResult } from '../../../typings';
+import type { CommitResult, SimpleGit } from '../../../typings';
+import type { SimpleGitApi } from '../simple-git-api';
+import type { StringTask } from '../types';
 import { parseCommitResult } from '../parsers/parse-commit';
-import { StringTask } from '../types';
+import {
+   asArray,
+   filterArray,
+   filterStringOrStringArray,
+   filterType,
+   getTrailingOptions, prefixedArray,
+   trailingFunctionArgument
+} from '../utils';
+import { configurationErrorTask } from './task';
 
 export function commitTask(message: string[], files: string[], customArgs: string[]): StringTask<CommitResult> {
-   const commands: string[] = ['commit'];
-
-   message.forEach((m) => commands.push('-m', m));
-
-   commands.push(
+   const commands: string[] = [
+      '-c',
+      'core.abbrev=40',
+      'commit',
+      ...prefixedArray(message, '-m'),
       ...files,
       ...customArgs,
-   );
+   ];
 
    return {
       commands,
       format: 'utf-8',
       parser: parseCommitResult,
+   };
+}
+
+export default function (): Pick<SimpleGit, 'commit'> {
+   return {
+      commit(this: SimpleGitApi, message: string | string[], ...rest: unknown[]) {
+         const next = trailingFunctionArgument(arguments);
+         const task = rejectDeprecatedSignatures(message) ||
+            commitTask(
+               asArray(message),
+               asArray(filterType(rest[0], filterStringOrStringArray, [])),
+               [...filterType(rest[1], filterArray, []), ...getTrailingOptions(arguments, 0, true)]
+            );
+
+         return this._runTask(task, next);
+      },
+   };
+
+   function rejectDeprecatedSignatures(message?: unknown) {
+      return (
+         !filterStringOrStringArray(message) &&
+         configurationErrorTask(`git.commit: requires the commit message to be supplied as a string/string[]`)
+      );
    }
 }

--- a/simple-git/src/lib/types/index.ts
+++ b/simple-git/src/lib/types/index.ts
@@ -1,7 +1,7 @@
-import { SpawnOptions } from 'child_process';
+import type { SpawnOptions } from 'child_process';
 
-import { SimpleGitTask } from './tasks';
-import { SimpleGitProgressEvent } from './handlers';
+import type { SimpleGitTask } from './tasks';
+import type { SimpleGitProgressEvent } from './handlers';
 
 export * from './handlers';
 export * from './tasks';

--- a/simple-git/test/integration/commit.spec.ts
+++ b/simple-git/test/integration/commit.spec.ts
@@ -1,0 +1,22 @@
+import { createTestContext, newSimpleGit, setUpInit, SimpleGitTestContext } from '../__fixtures__';
+
+describe('commit', () => {
+   let context: SimpleGitTestContext;
+
+   beforeEach(async () => context = await createTestContext());
+   beforeEach(async () => {
+      await setUpInit(context);
+      await context.files('hello', 'world');
+      await context.git.add('.');
+   });
+
+   it('details full commit hashes', async () => {
+      const result = await newSimpleGit(context.root).commit('commit message');
+
+      expect(result.commit.length).toBeGreaterThan(10);
+      expect(result.commit).toEqual(
+         await context.git.revparse('HEAD'),
+      );
+   });
+
+});

--- a/simple-git/test/unit/commit.spec.ts
+++ b/simple-git/test/unit/commit.spec.ts
@@ -1,3 +1,4 @@
+import { promiseError } from '@kwsites/promise-result';
 import {
    assertExecutedCommands,
    assertGitError,
@@ -11,7 +12,6 @@ import {
 } from './__fixtures__';
 import { SimpleGit, TaskConfigurationError } from '../..';
 import { parseCommitResult } from '../../src/lib/parsers/parse-commit';
-import { promiseError } from '@kwsites/promise-result';
 
 describe('commit', () => {
    let git: SimpleGit;
@@ -26,62 +26,62 @@ describe('commit', () => {
       it('empty commit', async () => {
          git.commit([], {'--amend': null, '--no-edit': null});
          await closeWithSuccess();
-         assertExecutedCommands('commit', '--amend', '--no-edit');
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '--amend', '--no-edit');
       });
 
       it('single message, no files, no options and callback', async () => {
          const task = git.commit('message', callback);
          await closeWithSuccess();
-         assertExecutedCommands('commit', '-m', 'message');
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '-m', 'message');
          expect(callback).toHaveBeenCalledWith(null, await task);
       });
 
       it('multi message, no files, no options and callback', async () => {
          const task = git.commit(['aaa', 'bbb'], callback);
          await closeWithSuccess();
-         assertExecutedCommands('commit', '-m', 'aaa', '-m', 'bbb');
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '-m', 'aaa', '-m', 'bbb');
          expect(callback).toHaveBeenCalledWith(null, await task);
       });
 
       it('single message, no files, with options object and callback', async () => {
          const task = git.commit('message', {'--opt': null}, callback);
          await closeWithSuccess();
-         assertExecutedCommands('commit', '-m', 'message', '--opt');
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '-m', 'message', '--opt');
          expect(callback).toHaveBeenCalledWith(null, await task);
       });
 
       it('single message, single file, options object and callback', async () => {
          const task = git.commit('msg', 'aaa.txt', {'--opt': null}, callback);
          await closeWithSuccess();
-         assertExecutedCommands('commit', '-m', 'msg', 'aaa.txt', '--opt');
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '-m', 'msg', 'aaa.txt', '--opt');
          expect(callback).toHaveBeenCalledWith(null, await task);
       });
 
       it('single message, single file, no options with callback', async () => {
          const task = git.commit('msg', 'aaa.txt', callback);
          await closeWithSuccess();
-         assertExecutedCommands('commit', '-m', 'msg', 'aaa.txt',);
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '-m', 'msg', 'aaa.txt',);
          expect(callback).toHaveBeenCalledWith(null, await task);
       });
 
       it('multi message, single file, no options with callback', async () => {
          const task = git.commit(['aaa', 'bbb'], 'aaa.txt', callback);
          await closeWithSuccess();
-         assertExecutedCommands('commit', '-m', 'aaa', '-m', 'bbb', 'aaa.txt');
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '-m', 'aaa', '-m', 'bbb', 'aaa.txt');
          expect(callback).toHaveBeenCalledWith(null, await task);
       });
 
       it('multi message, multi file, no options with callback', async () => {
          const task = git.commit(['aaa', 'bbb'], ['a.txt', 'b.txt'], callback);
          await closeWithSuccess();
-         assertExecutedCommands('commit', '-m', 'aaa', '-m', 'bbb', 'a.txt', 'b.txt');
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '-m', 'aaa', '-m', 'bbb', 'a.txt', 'b.txt');
          expect(callback).toHaveBeenCalledWith(null, await task);
       });
 
       it('multi message, multi file, options object with callback', async () => {
          const task = git.commit(['aaa', 'bbb'], ['a.txt', 'b.txt'], {'--foo': null}, callback);
          await closeWithSuccess();
-         assertExecutedCommands('commit', '-m', 'aaa', '-m', 'bbb', 'a.txt', 'b.txt', '--foo');
+         assertExecutedCommands('-c', 'core.abbrev=40', 'commit', '-m', 'aaa', '-m', 'bbb', 'a.txt', 'b.txt', '--foo');
          expect(callback).toHaveBeenCalledWith(null, await task);
       });
 
@@ -158,7 +158,7 @@ describe('commit', () => {
             branch: 'alpha',
             root: false
          }));
-      })
+      });
 
    });
 


### PR DESCRIPTION
Uses an inline configuration to require full commit hashes in the response to a `git.commit`

Closes #782 