### PR TITLE
Clear timeout upon stop to avoid hanging the process

### DIFF
--- a/.changeset/itchy-jobs-type.md
+++ b/.changeset/itchy-jobs-type.md
@@ -1,0 +1,5 @@
+---
+"simple-git": patch
+---
+
+Timeout plugin no longer keeps short lived processes alive until timeout is hit

--- a/simple-git/src/lib/plugins/timout-plugin.ts
+++ b/simple-git/src/lib/plugins/timout-plugin.ts
@@ -21,6 +21,7 @@ export function timeoutPlugin({block}: Exclude<SimpleGitOptions['timeout'], unde
                context.spawned.stderr?.off('data', wait);
                context.spawned.off('exit', stop);
                context.spawned.off('close', stop);
+               timeout && clearTimeout(timeout);
             }
 
             function kill() {


### PR DESCRIPTION
Clears the nodejs timeout upon stopping the listeners
Fixes #784 