### PR TITLE
Add Typescript types to the `simple-git` exports, for use when import…

### DIFF
--- a/.changeset/ninety-pots-tan.md
+++ b/.changeset/ninety-pots-tan.md
@@ -1,0 +1,5 @@
+---
+"simple-git": minor
+---
+
+Enable the use of types when loading with module-resolution

--- a/simple-git/package.json
+++ b/simple-git/package.json
@@ -71,6 +71,7 @@
     "types": "./dist/typings/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/typings/index.d.ts",
         "import": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js"
       },


### PR DESCRIPTION
…ing through module resolution which relies on named exports