### PR TITLE
Support `git.log` `--name-only` and `--name-status` options

### DIFF
--- a/.changeset/early-carpets-sniff.md
+++ b/.changeset/early-carpets-sniff.md
@@ -1,0 +1,5 @@
+---
+"simple-git": minor
+---
+
+Support `git.log` `--name-only` and `--name-status` options

--- a/simple-git/typings/response.d.ts
+++ b/simple-git/typings/response.d.ts
@@ -137,9 +137,9 @@ export interface ConfigValues {
 
 export interface DiffResultTextFile {
    file: string;
-   changes: number;
-   insertions: number;
-   deletions: number;
+   changes?: number;
+   insertions?: number;
+   deletions?: number;
    binary: false;
 }
 


### PR DESCRIPTION
Implementation proposal for #794.

I'm not very familiar with your stack or code style, so it's possible that the changes in this PR won't work for you. 
I've opened it until the support of these options is available in `simple-git`.