### PR TITLE
Support for log formats other than stat

### DIFF
--- a/.changeset/hot-chairs-battle.md
+++ b/.changeset/hot-chairs-battle.md
@@ -1,0 +1,7 @@
+---
+"simple-git": minor
+---
+
+Support for additional log formats in diffSummary / log / stashList.
+
+Adds support for the `--numstat`, `--name-only` and `--name-stat` in addition to the existing `--stat` option.

--- a/simple-git/readme.md
+++ b/simple-git/readme.md
@@ -186,10 +186,6 @@ For type details of the response for each of the tasks, please see the [TypeScri
 | `.commit(message, handlerFn)` | commits changes in the current working directory with the supplied message where the message can be either a single string or array of strings to be passed as separate arguments (the `git` command line interface converts these to be separated by double line breaks) |
 | `.commit(message, [fileA, ...], options, handlerFn)` | commits changes on the named files with the supplied message, when supplied, the optional options object can contain any other parameters to pass to the commit command, setting the value of the property to be a string will add `name=value` to the command string, setting any other type of value will result in just the key from the object being passed (ie: just `name`), an example of setting the author is below |
 | `.customBinary(gitPath)` | sets the command to use to reference git, allows for using a git binary not available on the path environment variable |
-| `.diff(options, handlerFn)` | get the diff of the current repo compared to the last commit with a set of options supplied as a string |
-| `.diff(handlerFn)` | get the diff for all file in the current repo compared to the last commit |
-| `.diffSummary(handlerFn)` | gets a summary of the diff for files in the repo, uses the `git diff --stat` format to calculate changes. Handler is called with a nullable error object and an instance of the [DiffSummary](https://github.com/steveukx/git-js/blob/main/simple-git/src/lib/responses/DiffSummary.js) |
-| `.diffSummary(options, handlerFn)` | includes options in the call to `diff --stat options` and returns a [DiffSummary](https://github.com/steveukx/git-js/blob/main/simple-git/src/lib/responses/DiffSummary.js) |
 | `.env(name, value)` | Set environment variables to be passed to the spawned child processes, [see usage in detail below](#environment-variables). |
 | `.exec(handlerFn)` | calls a simple function in the current step |
 | `.fetch([options, ] handlerFn)` | update the local working copy database with changes from the default remote repo and branch, when supplied the options argument can be a standard [options object](#how-to-specify-options) either an array of string commands as supported by the [git fetch](https://git-scm.com/docs/git-fetch). |
@@ -201,8 +197,6 @@ For type details of the response for each of the tasks, please see the [TypeScri
 | `.revert(commit [, options [, handlerFn]])` | reverts one or more commits in the working copy. The commit can be any regular commit-ish value (hash, name or offset such as `HEAD~2`) or a range of commits (eg: `master~5..master~2`). When supplied the [options](#how-to-specify-options) argument contain any options accepted by [git-revert](https://git-scm.com/docs/git-revert). |
 | `.rm([fileA, ...], handlerFn)` | removes any number of files from source control |
 | `.rmKeepLocal([fileA, ...], handlerFn)` | removes files from source control but leaves them on disk |
-| `.stash([options, ][ handlerFn])` | Stash the working directory, optional first argument can be an array of string arguments or [options](#how-to-specify-options) object to pass to the [git stash](https://git-scm.com/docs/git-stash) command. |
-| `.stashList([options, ][handlerFn])` | Retrieves the stash list, optional first argument can be an object specifying `options.splitter` to override the default value of `;;;;`, alternatively options can be a set of arguments as supported by the `git stash list` command. |
 | `.tag(args[], handlerFn)` | Runs any supported [git tag](https://git-scm.com/docs/git-tag) commands with arguments passed as an array of strings . |
 | `.tags([options, ] handlerFn)` | list all tags, use the optional [options](#how-to-specify-options) object to set any options allows by the [git tag](https://git-scm.com/docs/git-tag) command. Tags will be sorted by semantic version number by default, for git versions 2.7 and above, use the `--sort` option to set a custom sort. |
 | `.show([options], handlerFn)` | Show various types of objects, for example the file content at a certain commit. `options` is the single value string or array of string commands you want to run |
@@ -245,7 +239,6 @@ For type details of the response for each of the tasks, please see the [TypeScri
 
 - `mirror(repoPath, [localPath, [options]])` behaves the same as the `.clone` interface with the [`--mirror` flag](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---mirror) enabled.
 
-
 ## git config
 
 - `.addConfig(key, value, append = false, scope = 'local')` add a local configuration property, when `append` is set to
@@ -260,6 +253,17 @@ For type details of the response for each of the tasks, please see the [TypeScri
 
 - `.listConfig()` reads the current configuration and returns a [ConfigListSummary](https://github.com/steveukx/git-js/blob/main/simple-git/src/lib/responses/ConfigList.ts)
 - `.listConfig(scope: GitConfigScope)` as with `listConfig` but returns only those items in a specified scope (note that configuration values are overlaid on top of each other to build the config `git` will actually use - to resolve the configuration you are using use `(await listConfig()).all` without the scope argument)
+
+## git diff
+
+- `.diff([ options ])` get the diff of the current repo compared to the last commit, optionally including
+  any number of other arguments supported by [git diff](https://git-scm.com/docs/git-diff) supplied as an
+  [options](#how-to-specify-options) object/array. Returns the raw `diff` output as a string.
+
+- `.diffSummary([ options ])` creates a [DiffResult](https://github.com/steveukx/git-js/blob/main/simple-git/src/lib/responses/DiffSummary.ts)
+  to summarise the diff for files in the repo. Uses the `--stat` format by default which can be overridden
+  by passing in any of the log format commands (eg: `--numstat` or `--name-stat`) as part of the optional
+  [options](#how-to-specify-options) object/array.
 
 ## git grep [examples](https://github.com/steveukx/git-js/blob/main/examples/git-grep.md)
 
@@ -374,6 +378,12 @@ For type details of the response for each of the tasks, please see the [TypeScri
 - `.submoduleAdd(repo, path)` Adds a new sub module
 - `.submoduleInit([options]` Initialises sub modules, the optional [options](#how-to-specify-options) argument can be used to pass extra options to the `git submodule init` command.
 - `.submoduleUpdate(subModuleName, [options])` Updates sub modules, can be called with a sub module name and [options](#how-to-specify-options), just the options or with no arguments
+
+## git stash
+
+- `.stash([ options ])` Stash the working directory, optional first argument can be an array of string arguments or [options](#how-to-specify-options) object to pass to the [git stash](https://git-scm.com/docs/git-stash) command.
+
+- `.stashList([ options ])` Retrieves the stash list, optional first argument can be an object in the same format as used in [git log](#git-log).
 
 ## changing the working directory [examples](https://github.com/steveukx/git-js/blob/main/examples/git-change-working-directory.md)
 

--- a/simple-git/src/lib/args/log-format.ts
+++ b/simple-git/src/lib/args/log-format.ts
@@ -1,0 +1,25 @@
+
+export enum LogFormat {
+   NONE = '',
+   STAT = '--stat',
+   NUM_STAT = '--numstat',
+   NAME_ONLY = '--name-only',
+   NAME_STATUS = '--name-status',
+}
+
+const logFormatRegex = /^--(stat|numstat|name-only|name-status)(=|$)/;
+
+export function logFormatFromCommand(customArgs: string[]) {
+   for (let i = 0; i < customArgs.length; i++) {
+      const format = logFormatRegex.exec(customArgs[i]);
+      if (format) {
+         return `--${format[1]}` as LogFormat;
+      }
+   }
+
+   return LogFormat.NONE;
+}
+
+export function isLogFormat(customArg: string | unknown) {
+   return logFormatRegex.test(customArg as string);
+}

--- a/simple-git/src/lib/args/log-format.ts
+++ b/simple-git/src/lib/args/log-format.ts
@@ -1,4 +1,3 @@
-
 export enum LogFormat {
    NONE = '',
    STAT = '--stat',

--- a/simple-git/src/lib/errors/git-error.ts
+++ b/simple-git/src/lib/errors/git-error.ts
@@ -1,4 +1,4 @@
-import { SimpleGitTask } from '../types';
+import type { SimpleGitTask } from '../types';
 
 /**
  * The `GitError` is thrown when the underlying `git` process throws a

--- a/simple-git/src/lib/parsers/parse-branch-delete.ts
+++ b/simple-git/src/lib/parsers/parse-branch-delete.ts
@@ -23,7 +23,7 @@ const parsers: LineParser<BranchMultiDeleteResult>[] = [
 ];
 
 export const parseBranchDeletions: TaskParser<string, BranchMultiDeleteResult> = (stdOut, stdErr) => {
-   return parseStringResponse(new BranchDeletionBatch(), parsers, stdOut, stdErr);
+   return parseStringResponse(new BranchDeletionBatch(), parsers, [stdOut, stdErr]);
 }
 
 export function hasBranchDeletionError(data: string, processExitCode: ExitCodes): boolean {

--- a/simple-git/src/lib/parsers/parse-diff-summary.ts
+++ b/simple-git/src/lib/parsers/parse-diff-summary.ts
@@ -1,27 +1,10 @@
 import { DiffResult } from '../../../typings';
+import { LogFormat } from '../args/log-format';
 import { DiffSummary } from '../responses/DiffSummary';
 import { asNumber, LineParser, parseStringResponse } from '../utils';
 
-const parsers = {
-   summary: new LineParser<DiffResult>(/(\d+) files? changed\s*((?:, \d+ [^,]+){0,2})/, (result, [changed, summary]) => {
-      const inserted = /(\d+) i/.exec(summary);
-      const deleted = /(\d+) d/.exec(summary);
-
-      result.changed = asNumber(changed);
-      result.insertions = asNumber(inserted?.[1]);
-      result.deletions = asNumber(deleted?.[1]);
-   }),
-
-   binary: new LineParser<DiffResult>(/(.+) \|\s+Bin ([0-9.]+) -> ([0-9.]+) ([a-z]+)/, (result, [file, before, after]) => {
-      result.files.push({
-         file: file.trim(),
-         before: asNumber(before),
-         after: asNumber(after),
-         binary: true
-      });
-   }),
-
-   text: new LineParser<DiffResult>(/(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/, (result, [file, changes, alterations = '']) => {
+const statParser = [
+   new LineParser<DiffResult>(/(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/, (result, [file, changes, alterations = '']) => {
       result.files.push({
          file: file.trim(),
          changes: asNumber(changes),
@@ -30,16 +13,89 @@ const parsers = {
          binary: false
       });
    }),
-}
+   new LineParser<DiffResult>(/(.+) \|\s+Bin ([0-9.]+) -> ([0-9.]+) ([a-z]+)/, (result, [file, before, after]) => {
+      result.files.push({
+         file: file.trim(),
+         before: asNumber(before),
+         after: asNumber(after),
+         binary: true
+      });
+   }),
+   new LineParser<DiffResult>(/(\d+) files? changed\s*((?:, \d+ [^,]+){0,2})/, (result, [changed, summary]) => {
+      const inserted = /(\d+) i/.exec(summary);
+      const deleted = /(\d+) d/.exec(summary);
 
-export function parseDiffResult(stdOut: string): DiffResult {
-   const status = new DiffSummary();
+      result.changed = asNumber(changed);
+      result.insertions = asNumber(inserted?.[1]);
+      result.deletions = asNumber(deleted?.[1]);
+   })
+];
 
-   parseStringResponse(status, [
-      parsers.text,
-      parsers.binary,
-      parsers.summary,
-   ], stdOut);
+const numStatParser = [
+   new LineParser<DiffResult>(/(\d+)\t(\d+)\t(.+)$/, (result, [changesInsert, changesDelete, file]) => {
+      const insertions = asNumber(changesInsert);
+      const deletions = asNumber(changesDelete);
 
-   return status;
+      result.changed++;
+      result.insertions += insertions;
+      result.deletions += deletions;
+
+      result.files.push({
+         file,
+         changes: insertions + deletions,
+         insertions,
+         deletions,
+         binary: false,
+      });
+   }),
+   new LineParser<DiffResult>(/-\t-\t(.+)$/, (result, [file]) => {
+      result.changed++;
+
+      result.files.push({
+         file,
+         after: 0,
+         before: 0,
+         binary: true,
+      });
+   })
+];
+
+const nameOnlyParser = [
+   new LineParser<DiffResult>(/(.+)$/, (result, [file]) => {
+      result.changed++;
+      result.files.push({
+         file,
+         changes: 0,
+         insertions: 0,
+         deletions: 0,
+         binary: false,
+      });
+   })
+];
+
+const nameStatusParser = [
+   new LineParser<DiffResult>(/([ACDMRTUXB])\s*(.+)$/, (result, [_status, file]) => {
+      result.changed++;
+      result.files.push({
+         file,
+         changes: 0,
+         insertions: 0,
+         deletions: 0,
+         binary: false,
+      });
+   })
+];
+
+const diffSummaryParsers: Record<LogFormat, LineParser<DiffResult>[]> = {
+   [LogFormat.NONE]: statParser,
+   [LogFormat.STAT]: statParser,
+   [LogFormat.NUM_STAT]: numStatParser,
+   [LogFormat.NAME_STATUS]: nameStatusParser,
+   [LogFormat.NAME_ONLY]: nameOnlyParser,
+};
+
+export function getDiffParser(format = LogFormat.NONE) {
+   const parser = diffSummaryParsers[format];
+
+   return (stdOut: string) => parseStringResponse(new DiffSummary(), parser, stdOut);
 }

--- a/simple-git/src/lib/parsers/parse-diff-summary.ts
+++ b/simple-git/src/lib/parsers/parse-diff-summary.ts
@@ -97,5 +97,5 @@ const diffSummaryParsers: Record<LogFormat, LineParser<DiffResult>[]> = {
 export function getDiffParser(format = LogFormat.NONE) {
    const parser = diffSummaryParsers[format];
 
-   return (stdOut: string) => parseStringResponse(new DiffSummary(), parser, stdOut);
+   return (stdOut: string) => parseStringResponse(new DiffSummary(), parser, stdOut, false);
 }

--- a/simple-git/src/lib/parsers/parse-fetch.ts
+++ b/simple-git/src/lib/parsers/parse-fetch.ts
@@ -26,5 +26,5 @@ export function parseFetchResult (stdOut: string, stdErr: string): FetchResult {
       branches: [],
       tags: [],
    };
-   return parseStringResponse(result, parsers, stdOut, stdErr);
+   return parseStringResponse(result, parsers, [stdOut, stdErr]);
 }

--- a/simple-git/src/lib/parsers/parse-list-log-summary.ts
+++ b/simple-git/src/lib/parsers/parse-list-log-summary.ts
@@ -1,6 +1,7 @@
 import { ListLogLine, LogResult } from '../../../typings';
 import { toLinesWithContent } from '../utils';
-import { parseDiffResult } from './parse-diff-summary';
+import { getDiffParser } from './parse-diff-summary';
+import { LogFormat } from '../args/log-format';
 
 export const START_BOUNDARY = 'òòòòòò ';
 
@@ -17,7 +18,9 @@ function lineBuilder(tokens: string[], fields: string[]): any {
    }, Object.create({diff: null}) as any);
 }
 
-export function createListLogSummaryParser<T = any> (splitter = SPLITTER, fields = defaultFieldNames) {
+export function createListLogSummaryParser<T = any> (splitter = SPLITTER, fields = defaultFieldNames, logFormat = LogFormat.NONE) {
+   const parseDiffResult = getDiffParser(logFormat);
+
    return function (stdOut: string): LogResult<T> {
       const all: ReadonlyArray<T & ListLogLine> = toLinesWithContent(stdOut, true, START_BOUNDARY)
          .map(function (item) {

--- a/simple-git/src/lib/parsers/parse-pull.ts
+++ b/simple-git/src/lib/parsers/parse-pull.ts
@@ -47,7 +47,7 @@ const errorParsers: LineParser<PullFailedResult>[] = [
 ];
 
 export const parsePullDetail: TaskParser<string, PullDetail> = (stdOut, stdErr) => {
-   return parseStringResponse(new PullSummary(), parsers, stdOut, stdErr);
+   return parseStringResponse(new PullSummary(), parsers, [stdOut, stdErr]);
 }
 
 export const parsePullResult: TaskParser<string, PullResult> = (stdOut, stdErr) => {
@@ -59,7 +59,7 @@ export const parsePullResult: TaskParser<string, PullResult> = (stdOut, stdErr) 
 }
 
 export function parsePullErrorResult(stdOut: string, stdErr: string) {
-   const pullError = parseStringResponse(new PullFailedSummary(), errorParsers, stdOut, stdErr);
+   const pullError = parseStringResponse(new PullFailedSummary(), errorParsers, [stdOut, stdErr]);
 
    return pullError.message && pullError;
 }

--- a/simple-git/src/lib/parsers/parse-push.ts
+++ b/simple-git/src/lib/parsers/parse-push.ts
@@ -65,5 +65,5 @@ export const parsePushResult: TaskParser<string, PushResult> = (stdOut, stdErr) 
 }
 
 export const parsePushDetail: TaskParser<string, PushDetail> = (stdOut, stdErr) => {
-   return parseStringResponse({pushed: []}, parsers, stdOut, stdErr);
+   return parseStringResponse({pushed: []}, parsers, [stdOut, stdErr]);
 }

--- a/simple-git/src/lib/tasks/diff.ts
+++ b/simple-git/src/lib/tasks/diff.ts
@@ -1,13 +1,32 @@
 import { StringTask } from '../types';
 import { DiffResult } from '../../../typings';
-import { parseDiffResult } from '../parsers/parse-diff-summary';
+import { isLogFormat, LogFormat, logFormatFromCommand } from '../args/log-format';
+import { getDiffParser } from '../parsers/parse-diff-summary';
+import { configurationErrorTask, EmptyTask } from './task';
 
 export function diffSummaryTask(customArgs: string[]): StringTask<DiffResult> {
+   let logFormat = logFormatFromCommand(customArgs);
+
+   const commands = ['diff'];
+
+   if (logFormat === LogFormat.NONE) {
+      logFormat = LogFormat.STAT;
+      commands.push('--stat=4096');
+   }
+
+   commands.push(...customArgs);
+
    return {
-      commands: ['diff', '--stat=4096', ...customArgs],
+      commands,
       format: 'utf-8',
-      parser (stdOut) {
-         return parseDiffResult(stdOut);
-      }
+      parser: getDiffParser(logFormat),
+   }
+}
+
+export function validateSummaryOptions(customArgs: unknown[]): EmptyTask | void {
+   const flags = customArgs.filter(isLogFormat);
+
+   if (flags.length > 1) {
+      return configurationErrorTask(`Summary flags are mutually exclusive - pick one of ${flags.join(',')}`);
    }
 }

--- a/simple-git/src/lib/tasks/log.ts
+++ b/simple-git/src/lib/tasks/log.ts
@@ -1,5 +1,5 @@
-import { Options, StringTask } from '../types';
-import { LogResult, SimpleGit } from '../../../typings';
+import type { Options, StringTask } from '../types';
+import type { LogResult, SimpleGit } from '../../../typings';
 import { logFormatFromCommand } from '../args/log-format';
 import {
    COMMIT_BOUNDARY,
@@ -18,7 +18,7 @@ import {
 } from '../utils';
 import { SimpleGitApi } from '../simple-git-api';
 import { configurationErrorTask } from './task';
-import { validateSummaryOptions } from './diff';
+import { validateLogFormatConfig } from './diff';
 
 enum excludeOptions {
    '--pretty',
@@ -150,8 +150,8 @@ export default function (): Pick<SimpleGit, 'log'> {
          const next = trailingFunctionArgument(arguments);
          const options = parseLogOptions<T>(trailingOptionsArgument(arguments), filterType(arguments[0], filterArray));
          const task = rejectDeprecatedSignatures(...rest) ||
-            validateSummaryOptions(options.commands) ||
-            createLogTask(options)
+            validateLogFormatConfig(options.commands) ||
+            createLogTask(options);
 
          return this._runTask(task, next);
       }

--- a/simple-git/src/lib/tasks/stash-list.ts
+++ b/simple-git/src/lib/tasks/stash-list.ts
@@ -1,15 +1,17 @@
 import { LogOptions, LogResult } from '../../../typings';
 import { logFormatFromCommand } from '../args/log-format';
 import { createListLogSummaryParser } from '../parsers/parse-list-log-summary';
-import { StringTask } from '../types';
+import type { StringTask } from '../types';
+import { validateLogFormatConfig } from './diff';
 import { parseLogOptions } from './log';
+import type { EmptyTask } from './task';
 
-export function stashListTask(opt: LogOptions = {}, customArgs: string[]): StringTask<LogResult> {
+export function stashListTask(opt: LogOptions = {}, customArgs: string[]): EmptyTask | StringTask<LogResult> {
    const options = parseLogOptions<any>(opt);
    const commands = ['stash', 'list', ...options.commands, ...customArgs];
    const parser = createListLogSummaryParser(options.splitter, options.fields, logFormatFromCommand(commands));
 
-   return {
+   return validateLogFormatConfig(commands) || {
       commands,
       format: 'utf-8',
       parser,

--- a/simple-git/src/lib/tasks/stash-list.ts
+++ b/simple-git/src/lib/tasks/stash-list.ts
@@ -1,14 +1,16 @@
 import { LogOptions, LogResult } from '../../../typings';
+import { logFormatFromCommand } from '../args/log-format';
 import { createListLogSummaryParser } from '../parsers/parse-list-log-summary';
 import { StringTask } from '../types';
 import { parseLogOptions } from './log';
 
 export function stashListTask(opt: LogOptions = {}, customArgs: string[]): StringTask<LogResult> {
    const options = parseLogOptions<any>(opt);
-   const parser = createListLogSummaryParser(options.splitter, options.fields);
+   const commands = ['stash', 'list', ...options.commands, ...customArgs];
+   const parser = createListLogSummaryParser(options.splitter, options.fields, logFormatFromCommand(commands));
 
    return {
-      commands: ['stash', 'list', ...options.commands, ...customArgs],
+      commands,
       format: 'utf-8',
       parser,
    };

--- a/simple-git/src/lib/tasks/task.ts
+++ b/simple-git/src/lib/tasks/task.ts
@@ -1,5 +1,5 @@
 import { TaskConfigurationError } from '../errors/task-configuration-error';
-import { BufferTask, EmptyTaskParser, SimpleGitTask, StringTask } from '../types';
+import type { BufferTask, EmptyTaskParser, SimpleGitTask, StringTask } from '../types';
 
 export const EMPTY_COMMANDS: [] = [];
 

--- a/simple-git/src/lib/utils/task-parser.ts
+++ b/simple-git/src/lib/utils/task-parser.ts
@@ -1,15 +1,15 @@
-import { TaskParser, TaskResponseFormat } from '../types';
+import type { MaybeArray, TaskParser, TaskResponseFormat } from '../types';
 import { GitOutputStreams } from './git-output-streams';
 import { LineParser } from './line-parser';
-import { toLinesWithContent } from './util';
+import { asArray, toLinesWithContent } from './util';
 
 export function callTaskParser<INPUT extends TaskResponseFormat, RESPONSE>(parser: TaskParser<INPUT, RESPONSE>, streams: GitOutputStreams<INPUT>) {
    return parser(streams.stdOut, streams.stdErr);
 }
 
-export function parseStringResponse<T>(result: T, parsers: LineParser<T>[], ...texts: string[]): T {
-   texts.forEach(text => {
-      for (let lines = toLinesWithContent(text), i = 0, max = lines.length; i < max; i++) {
+export function parseStringResponse<T>(result: T, parsers: LineParser<T>[], texts: MaybeArray<string>, trim = true): T {
+   asArray(texts).forEach(text => {
+      for (let lines = toLinesWithContent(text, trim), i = 0, max = lines.length; i < max; i++) {
          const line = (offset = 0) => {
             if ((i + offset) >= max) {
                return;

--- a/simple-git/test/integration/diff.spec.ts
+++ b/simple-git/test/integration/diff.spec.ts
@@ -1,0 +1,44 @@
+import {
+   createTestContext,
+   like,
+   newSimpleGit,
+   setUpFilesAdded,
+   setUpInit,
+   SimpleGitTestContext
+} from '../__fixtures__';
+
+describe('diff', function () {
+   const nameWithTrailingSpaces = 'name-with-trailing-spaces  ';
+   const fileContent = Array(10).fill('Some content on this line\n').join('');
+   const nextContent = Array(5).fill('Some content on this line\nDifferent on this line\n').join('');
+
+   let context: SimpleGitTestContext;
+
+   beforeEach(async () => {
+      context = await createTestContext();
+      await setUpInit(context);
+      await setUpFilesAdded(context, [nameWithTrailingSpaces], '.', fileContent);
+      await context.file(nameWithTrailingSpaces, nextContent);
+   });
+
+   it('detects diff with --numstat', async () => {
+      const diff = await newSimpleGit(context.root).diffSummary(['--numstat']);
+
+      expect(diff).toEqual(like({
+         changed: 1,
+         deletions: 1,
+         insertions: 10,
+         files: [
+            {
+               file: nameWithTrailingSpaces,
+               changes: 11,
+               insertions: 10,
+               deletions: 1,
+               binary: false,
+            }
+         ]
+      }));
+   });
+
+
+});

--- a/simple-git/test/unit/args.log-format.spec.ts
+++ b/simple-git/test/unit/args.log-format.spec.ts
@@ -1,0 +1,22 @@
+import { LogFormat, logFormatFromCommand } from '../../src/lib/args/log-format';
+
+describe('log-format', function () {
+
+   it.each<[LogFormat, string[]]>([
+      [LogFormat.NONE, []],
+      [LogFormat.NONE, ['foo', 'bar', '--nothing']],
+      [LogFormat.STAT, ['foo', '--stat', 'bar']],
+      [LogFormat.STAT, ['foo', '--stat=4096', '--bar']],
+      [LogFormat.NUM_STAT, ['foo', '--numstat', '--bar']],
+      [LogFormat.NAME_ONLY, ['--name-only', 'foo', '--bar']],
+      [LogFormat.NAME_STATUS, ['--name-status']],
+   ])('Picks %s from %s', (format, args) => {
+      expect(logFormatFromCommand(args)).toBe(format);
+   });
+
+   it('picks the first format', () => {
+      expect(logFormatFromCommand(['--stat', '--numstat'])).toBe(LogFormat.STAT);
+      expect(logFormatFromCommand(['--numstat', '--stat'])).toBe(LogFormat.NUM_STAT);
+   });
+
+});

--- a/simple-git/test/unit/diff.spec.ts
+++ b/simple-git/test/unit/diff.spec.ts
@@ -10,7 +10,8 @@ import {
    wait
 } from './__fixtures__';
 import { SimpleGit, TaskConfigurationError } from '../..';
-import { parseDiffResult } from '../../src/lib/parsers/parse-diff-summary';
+import { LogFormat } from '../../src/lib/args/log-format';
+import { getDiffParser } from '../../src/lib/parsers/parse-diff-summary';
 import { promiseError } from '@kwsites/promise-result';
 
 describe('diff', () => {
@@ -20,7 +21,7 @@ describe('diff', () => {
    describe('parsing', () => {
 
       it('bin summary', () => {
-         const summary = parseDiffResult(`
+         const summary = getDiffParser(LogFormat.STAT)(`
  my-package.tar.gz | Bin 3163 -> 3244 bytes
  1 file changed, 0 insertions(+), 0 deletions(-)
  `);
@@ -37,7 +38,7 @@ describe('diff', () => {
       });
 
       it('single text file with changes', () => {
-         const actual = parseDiffResult(
+         const actual = getDiffParser(LogFormat.STAT)(
             diffSummarySingleFile(1, 2, 'package.json').stdOut
          );
          expect(actual).toEqual(like({
@@ -58,7 +59,7 @@ describe('diff', () => {
       });
 
       it('multiple text files', () => {
-         const actual = parseDiffResult(diffSummaryMultiFile(
+         const actual = getDiffParser(LogFormat.STAT)(diffSummaryMultiFile(
             {fileName: 'src/git.js', insertions: 2},
             {fileName: 'test/testCommands.js', deletions: 2, insertions: 1},
          ).stdOut);
@@ -87,7 +88,7 @@ describe('diff', () => {
       });
 
       it('recognises binary files', () => {
-         const actual = parseDiffResult(`
+         const actual = getDiffParser(LogFormat.STAT)(`
             some/image.png     |       Bin 0 -> 9806 bytes
             1 file changed, 1 insertion(+)
          `);
@@ -105,7 +106,7 @@ describe('diff', () => {
       });
 
       it('recognises files changed in modified time only', () => {
-         const actual = parseDiffResult(`
+         const actual = getDiffParser(LogFormat.STAT)(`
       abc | 0
       def | 1 +
       2 files changed, 1 insertion(+)
@@ -120,8 +121,8 @@ describe('diff', () => {
       });
 
       it('picks number of files changed from summary line', () => {
-         expect(parseDiffResult('1 file changed, 1 insertion(+)')).toHaveProperty('changed', 1);
-         expect(parseDiffResult('2 files changed, 1 insertion(+), 1 deletion(+)')).toHaveProperty('changed', 2);
+         expect(getDiffParser(LogFormat.STAT)('1 file changed, 1 insertion(+)')).toHaveProperty('changed', 1);
+         expect(getDiffParser(LogFormat.STAT)('2 files changed, 1 insertion(+), 1 deletion(+)')).toHaveProperty('changed', 2);
       });
 
    });


### PR DESCRIPTION
The same parser is used to read per-file change summaries for `diff`, `log` and `stash` commands.

At present the format is assumed to always be `--stat=4096` so any use passing in alternative formats as custom options will find the result has either inaccurate information or misses files completely.

This change adds support for `--numstat` `--name-only` `--name-stat` and `--stat` in  `git.diffSummary`, `git.log` and `git.stashList`.

