### PR TITLE
Add support for parsing linked worktree branches

### DIFF
--- a/.changeset/pink-gravy-boat.md
+++ b/.changeset/pink-gravy-boat.md
@@ -1,0 +1,5 @@
+---
+"simple-git": minor
+---
+
+Branches that have been checked out as a [linked work tree](https://git-scm.com/docs/git-worktree) will now be included in the `BranchSummary` output, with a `linkedWorkTree` property set to `true` in the `BranchSummaryBranch`. 

--- a/simple-git/src/lib/parsers/parse-branch.ts
+++ b/simple-git/src/lib/parsers/parse-branch.ts
@@ -1,24 +1,28 @@
-import { BranchSummary } from '../../../typings';
+import type { BranchSummary } from '../../../typings';
 import { BranchSummaryResult } from '../responses/BranchSummary';
 import { LineParser, parseStringResponse } from '../utils';
 
 const parsers: LineParser<BranchSummaryResult>[] = [
-   new LineParser(/^(\*\s)?\((?:HEAD )?detached (?:from|at) (\S+)\)\s+([a-z0-9]+)\s(.*)$/, (result, [current, name, commit, label]) => {
+   new LineParser(/^([*+]\s)?\((?:HEAD )?detached (?:from|at) (\S+)\)\s+([a-z0-9]+)\s(.*)$/, (result, [current, name, commit, label]) => {
       result.push(
-         !!current,
+         branchStatus(current),
          true,
          name, commit, label
       );
    }),
-   new LineParser(/^(\*\s)?(\S+)\s+([a-z0-9]+)\s?(.*)$/s, (result, [current, name, commit, label]) => {
+   new LineParser(/^([*+]\s)?(\S+)\s+([a-z0-9]+)\s?(.*)$/s, (result, [current, name, commit, label]) => {
       result.push(
-         !!current,
+         branchStatus(current),
          false,
          name, commit, label
       );
    })
 ];
 
-export function parseBranchSummary (stdOut: string): BranchSummary {
+function branchStatus(input?: string) {
+   return input ? input.charAt(0) : '';
+}
+
+export function parseBranchSummary(stdOut: string): BranchSummary {
    return parseStringResponse(new BranchSummaryResult(), parsers, stdOut);
 }

--- a/simple-git/src/lib/responses/BranchSummary.ts
+++ b/simple-git/src/lib/responses/BranchSummary.ts
@@ -1,4 +1,9 @@
-import { BranchSummary, BranchSummaryBranch } from '../../../typings';
+import type { BranchSummary, BranchSummaryBranch } from '../../../typings';
+
+export enum BranchStatusIdentifier {
+   CURRENT = '*',
+   LINKED = '+',
+}
 
 export class BranchSummaryResult implements BranchSummary {
    public all: string[] = [];
@@ -6,18 +11,19 @@ export class BranchSummaryResult implements BranchSummary {
    public current: string = '';
    public detached: boolean = false;
 
-   push(current: boolean, detached: boolean, name: string, commit: string, label: string) {
-      if (current) {
+   push(status: BranchStatusIdentifier | unknown, detached: boolean, name: string, commit: string, label: string) {
+      if (status === BranchStatusIdentifier.CURRENT) {
          this.detached = detached;
          this.current = name;
       }
 
       this.all.push(name);
       this.branches[name] = {
-         current: current,
-         name: name,
-         commit: commit,
-         label: label
+         current: status === BranchStatusIdentifier.CURRENT,
+         linkedWorkTree: status === BranchStatusIdentifier.LINKED,
+         name,
+         commit,
+         label
       };
    }
 }

--- a/simple-git/test/unit/branch.spec.ts
+++ b/simple-git/test/unit/branch.spec.ts
@@ -273,6 +273,7 @@ describe('branch', () => {
                   current: false,
                   label: '',
                   name: 'remotes/origin/stable',
+                  linkedWorkTree: false,
                },
                dev: {
                   commit: 'f8cc2be',

--- a/simple-git/test/unit/branch.spec.ts
+++ b/simple-git/test/unit/branch.spec.ts
@@ -119,23 +119,25 @@ describe('branch', () => {
                   current: false,
                   label: 'Something',
                   name: 'branch-012de2',
+                  linkedWorkTree: false,
                },
                'branch-012de3': {
                   commit: '012de3',
                   current: true,
                   label: 'Add support for carriage \r returns',
                   name: 'branch-012de3',
+                  linkedWorkTree: false,
                },
                'branch-012de4': {
                   commit: '012de4',
                   current: false,
                   label: 'Something else',
                   name: 'branch-012de4',
+                  linkedWorkTree: false,
                },
             }
          }))
       });
-
 
 
       it('branch detail by name', async () => {
@@ -154,18 +156,21 @@ describe('branch', () => {
                   current: false,
                   label: 'Add support for filenames containing spaces',
                   name: 'cflynn07-add-git-ignore',
+                  linkedWorkTree: false,
                },
                'drschwabe-add-branches': {
                   commit: '063069b',
                   current: true,
                   label: `Merge branch 'add-branches' of https://github.com/user/repo into drschwabe-add-branches`,
                   name: 'drschwabe-add-branches',
+                  linkedWorkTree: false,
                },
                master: {
                   commit: 'cb4be06',
                   current: false,
                   label: 'Release 1.30.0',
                   name: 'master',
+                  linkedWorkTree: false,
                },
             },
          }));
@@ -210,6 +215,42 @@ describe('branch', () => {
          }));
       });
 
+      it(`branches in linked work trees`, () => {
+         const actual = parseBranchSummary(`
+  main 3c43b1d first
+* x    e94b8dd second
++ y    3c43b1d first
+         `);
+
+         expect(actual).toEqual(like({
+            current: 'x',
+            all: ['main', 'x', 'y'],
+            branches: {
+               main: {
+                  commit: '3c43b1d',
+                  current: false,
+                  label: 'first',
+                  linkedWorkTree: false,
+                  name: 'main',
+               },
+               x: {
+                  commit: 'e94b8dd',
+                  current: true,
+                  label: 'second',
+                  linkedWorkTree: false,
+                  name: 'x',
+               },
+               y: {
+                  commit: '3c43b1d',
+                  current: false,
+                  label: 'first',
+                  linkedWorkTree: true,
+                  name: 'y',
+               },
+            }
+         }));
+      })
+
       it('branches without labels', async () => {
          const actual = parseBranchSummary(`
 * stable                f8cc2bc
@@ -225,8 +266,9 @@ describe('branch', () => {
                   current: true,
                   label: '',
                   name: 'stable',
+                  linkedWorkTree: false,
                },
-               ['remotes/origin/stable']: {
+               'remotes/origin/stable': {
                   commit: 'f8cc2bd',
                   current: false,
                   label: '',
@@ -237,6 +279,7 @@ describe('branch', () => {
                   current: false,
                   label: 'wip',
                   name: 'dev',
+                  linkedWorkTree: false,
                },
             }
          }));

--- a/simple-git/typings/response.d.ts
+++ b/simple-git/typings/response.d.ts
@@ -5,6 +5,7 @@ export interface BranchSummaryBranch {
    name: string;
    commit: string;
    label: string;
+   linkedWorkTree: boolean;
 }
 
 export interface BranchSummary {


### PR DESCRIPTION
Branches that have been checked out as a [linked work tree](https://git-scm.com/docs/git-worktree) will now be included in the `BranchSummary` output, with a `linkedWorkTree` property set to `true` in the `BranchSummaryBranch`.

Closes #811