### PR TITLE
Support for TypeScript ESM

### DIFF
--- a/.changeset/skipping-gold-skips.md
+++ b/.changeset/skipping-gold-skips.md
@@ -1,0 +1,10 @@
+---
+"@simple-git/test-es-module-consumer": patch
+"@simple-git/teset-javascript-consumer": patch
+"@simple-git/test-typescript-consumer": patch
+"@simple-git/test-typescript-esm-consumer": patch
+"simple-git": minor
+---
+
+Support for importing as an ES module with TypeScript moduleResolution `node16` or newer by adding
+`simpleGit` as a named export.

--- a/docs/DEBUG-LOGGING-GUIDE.md
+++ b/docs/DEBUG-LOGGING-GUIDE.md
@@ -21,7 +21,7 @@ simpleGit().init().then(() => console.log('DONE'));
 
 ```typescript
 import debug from 'debug';
-import simpleGit from 'simple-git';
+import { simpleGit } from 'simple-git';
 
 debug.enable('simple-git,simple-git:*');
 simpleGit().init().then(() => console.log('DONE'));

--- a/docs/LEGACY_NODE_VERSIONS.md
+++ b/docs/LEGACY_NODE_VERSIONS.md
@@ -2,6 +2,7 @@
 # Legacy Node Versions
 
 From `v3.x`, `simple-git` will drop support for `node.js` version 10 or below.
+From `v3.8`, `simple-git` will no longer be tested against node version 12 or below.
 
 To use in lower versions of node, ensure you are also including the necessary polyfills from `core-js`:
 

--- a/docs/PLUGIN-COMPLETION-DETECTION.md
+++ b/docs/PLUGIN-COMPLETION-DETECTION.md
@@ -12,7 +12,7 @@ From version `2.46.0` onwards, you can configure this behaviour by using the
 `completion` plugin:
 
 ```typescript
-import simpleGit, { SimpleGit } from 'simple-git';
+import { simpleGit, SimpleGit } from 'simple-git';
 
 const git: SimpleGit = simpleGit({
    completion: {

--- a/docs/PLUGIN-ERRORS.md
+++ b/docs/PLUGIN-ERRORS.md
@@ -13,7 +13,7 @@ detection plugin is the original error. Either return that error directly to all
 task's error handlers, or implement your own error detection as below:
 
 ```typescript
-import simpleGit from 'simple-git';
+import { simpleGit } from 'simple-git';
 
 const git = simpleGit({
    errors(error, result) {

--- a/docs/PLUGIN-PROGRESS-EVENTS.md
+++ b/docs/PLUGIN-PROGRESS-EVENTS.md
@@ -3,7 +3,7 @@
 To receive progress updates, pass a `progress` configuration option to the `simpleGit` instance:
 
 ```typescript
-import simpleGit, { SimpleGit, SimpleGitProgressEvent } from 'simple-git';
+import { simpleGit, SimpleGit, SimpleGitProgressEvent } from 'simple-git';
 
 const progress = ({method, stage, progress}: SimpleGitProgressEvent) => {
    console.log(`git.${method} ${stage} stage ${progress}% complete`);

--- a/docs/PLUGIN-TIMEOUT.md
+++ b/docs/PLUGIN-TIMEOUT.md
@@ -5,7 +5,7 @@ To handle the case where the underlying `git` processes appear to hang, configur
 `stdOut` or `stdErr` streams before sending a `SIGINT` kill message.
 
 ```typescript
-import simpleGit, { GitPluginError, SimpleGit, SimpleGitProgressEvent } from 'simple-git';
+import { simpleGit, GitPluginError, SimpleGit, SimpleGitProgressEvent } from 'simple-git';
 
 const git: SimpleGit = simpleGit({
    baseDir: '/some/path', 

--- a/examples/git-change-working-directory.md
+++ b/examples/git-change-working-directory.md
@@ -5,7 +5,7 @@ when it is created by using the `baseDir` property:
 
 ```typescript
 import { join } from 'path';
-import simpleGit from 'simple-git';
+import { simpleGit } from 'simple-git';
 
 const git = simpleGit({ baseDir: join(__dirname, 'repos') });
 ```
@@ -14,7 +14,7 @@ Or explicitly set the working directory at some later time, for example after cl
 
 ```typescript
 import { join } from 'path';
-import simpleGit, { SimpleGit } from 'simple-git';
+import { simpleGit, SimpleGit } from 'simple-git';
 
 const remote = `https://github.com/steveukx/git-js.git`;
 const target = join(__dirname, 'repos', 'git-js');
@@ -29,7 +29,7 @@ are treated as an atomic operation. To rewrite this using separate `async/await`
 
 ```typescript
 import { join } from 'path';
-import simpleGit, { SimpleGit } from 'simple-git';
+import { simpleGit, SimpleGit } from 'simple-git';
 
 const remote = `https://github.com/steveukx/git-js.git`;
 const target = join(__dirname, 'repos', 'git-js');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "simple-git"
   ],
   "resolutions": {
-    "typescript": "4.1.2"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "build": "lerna run build",

--- a/packages/test-es-module-consumer/suite.mjs
+++ b/packages/test-es-module-consumer/suite.mjs
@@ -1,0 +1,28 @@
+import { strictEqual } from "assert";
+
+export async function suite(name, simpleGit, ResetMode) {
+   exec(`${name}: imports default`, async () => {
+      strictEqual(
+         await simpleGit().checkIsRepo(),
+         true,
+         'expected the current directory to be a valid git root',
+      );
+   });
+
+   exec(`${name}: imports named exports`, async () => {
+      strictEqual(
+         /hard/.test(ResetMode.HARD),
+         true,
+         'expected valid ResetMode enum'
+      );
+   });
+}
+
+function exec (name, runner) {
+   runner()
+      .then(() => console.log(`${ name }: OK`))
+      .catch((e) => {
+         console.error(`${ name }: ${ e.message }`);
+         throw e;
+      });
+}

--- a/packages/test-es-module-consumer/test-default-as.mjs
+++ b/packages/test-es-module-consumer/test-default-as.mjs
@@ -1,0 +1,4 @@
+import { simpleGit, ResetMode } from 'simple-git';
+import { suite } from './suite.mjs';
+
+await suite('import named', simpleGit, ResetMode);

--- a/packages/test-es-module-consumer/test-default.mjs
+++ b/packages/test-es-module-consumer/test-default.mjs
@@ -1,0 +1,4 @@
+import simpleGit, { ResetMode } from 'simple-git';
+import { suite } from './suite.mjs';
+
+await suite('import default', simpleGit, ResetMode);

--- a/packages/test-es-module-consumer/test-named.mjs
+++ b/packages/test-es-module-consumer/test-named.mjs
@@ -1,0 +1,4 @@
+import { default as simpleGit, ResetMode } from 'simple-git';
+import { suite } from './suite.mjs';
+
+await suite('import default-as', simpleGit, ResetMode);

--- a/packages/test-es-module-consumer/test.mjs
+++ b/packages/test-es-module-consumer/test.mjs
@@ -1,27 +1,3 @@
-import { strictEqual } from 'assert';
-import simpleGit, { ResetMode } from 'simple-git';
-
-exec('imports default', async () => {
-   strictEqual(
-      await simpleGit().checkIsRepo(),
-      true,
-      'expected the current directory to be a valid git root',
-   );
-});
-
-exec('imports named exports', async () => {
-   strictEqual(
-      /hard/.test(ResetMode.HARD),
-      true,
-      'expected valid ResetMode enum'
-   );
-});
-
-function exec (name, runner) {
-   runner()
-      .then(() => console.log(`${ name }: OK`))
-      .catch((e) => {
-         console.error(`${ name }: ${ e.message }`);
-         throw e;
-      });
-}
+import './test-default.mjs';
+import './test-default-as.mjs';
+import './test-named.mjs';

--- a/packages/test-javascript-consumer/suite.js
+++ b/packages/test-javascript-consumer/suite.js
@@ -1,0 +1,30 @@
+const {strictEqual} = require('assert');
+
+module.exports = {
+   async suite (name, simpleGit, ResetMode) {
+      exec(`${ name }: imports default`, async () => {
+         strictEqual(
+            await simpleGit().checkIsRepo(),
+            true,
+            'expected the current directory to be a valid git root',
+         );
+      });
+
+      exec(`${ name }: imports named exports`, async () => {
+         strictEqual(
+            /hard/.test(ResetMode.HARD),
+            true,
+            'expected valid ResetMode enum'
+         );
+      });
+   }
+};
+
+function exec (name, runner) {
+   runner()
+      .then(() => console.log(`${ name }: OK`))
+      .catch((e) => {
+         console.error(`${ name }: ${ e.message }`);
+         throw e;
+      });
+}

--- a/packages/test-javascript-consumer/test-default-as.js
+++ b/packages/test-javascript-consumer/test-default-as.js
@@ -1,0 +1,6 @@
+const {default: simpleGit, ResetMode} = require('simple-git');
+const {suite} = require('./suite');
+
+(async () => {
+   await suite('require default-as', simpleGit, ResetMode);
+})();

--- a/packages/test-javascript-consumer/test-default.js
+++ b/packages/test-javascript-consumer/test-default.js
@@ -1,27 +1,7 @@
-const {default: simpleGit, ResetMode} = require('simple-git');
-const {strictEqual} = require("assert");
+const simpleGit = require('simple-git');
+const {suite} = require('./suite');
 
-exec('requires default', async () => {
-   strictEqual(
-      await simpleGit().checkIsRepo(),
-      true,
-      'expected the current directory to be a valid git root',
-   );
-});
+(async () => {
+   await suite('require default', simpleGit, simpleGit.ResetMode);
+})();
 
-exec('imports named exports', async () => {
-   strictEqual(
-      /hard/.test(ResetMode.HARD),
-      true,
-      'expected valid ResetMode enum'
-   );
-});
-
-function exec (name, runner) {
-   runner()
-      .then(() => console.log(`${ name }: OK`))
-      .catch((e) => {
-         console.error(`${ name }: ${ e.message }`);
-         throw e;
-      });
-}

--- a/packages/test-javascript-consumer/test-named.js
+++ b/packages/test-javascript-consumer/test-named.js
@@ -1,0 +1,7 @@
+const {simpleGit, ResetMode} = require('simple-git');
+const {suite} = require('./suite');
+
+(async () => {
+   await suite('require named', simpleGit, ResetMode);
+})();
+

--- a/packages/test-javascript-consumer/test.js
+++ b/packages/test-javascript-consumer/test.js
@@ -1,27 +1,3 @@
-const simpleGit = require('simple-git');
-const {strictEqual} = require("assert");
-
-exec('requires default', async () => {
-   strictEqual(
-      await simpleGit().checkIsRepo(),
-      true,
-      'expected the current directory to be a valid git root',
-   );
-});
-
-exec('imports named exports', async () => {
-   strictEqual(
-      /hard/.test(simpleGit.ResetMode.HARD),
-      true,
-      'expected valid ResetMode enum'
-   );
-});
-
-function exec (name, runner) {
-   runner()
-      .then(() => console.log(`${ name }: OK`))
-      .catch((e) => {
-         console.error(`${ name }: ${ e.message }`);
-         throw e;
-      });
-}
+require('./test-default');
+require('./test-default-as');
+require('./test-named');

--- a/packages/test-typescript-consumer/test/ts-named-import.spec.ts
+++ b/packages/test-typescript-consumer/test/ts-named-import.spec.ts
@@ -1,0 +1,47 @@
+import simpleGit, { gitP, CleanOptions, SimpleGit, TaskConfigurationError } from 'simple-git';
+
+describe('simple-git', () => {
+
+   describe('default export', () => {
+      it('is the simple-git factory', async () => {
+         expect(await simpleGit().checkIsRepo()).toBe(true);
+      });
+
+      it('builds exported types', async () => {
+         const git: SimpleGit = simpleGit();
+
+         expect(git).not.toBeUndefined();
+      });
+   });
+
+   describe('gitP export', () => {
+      it('is the simple-git factory', async () => {
+         expect(await gitP().checkIsRepo()).toBe(true);
+      });
+
+      it('builds exported types', async () => {
+         const git: SimpleGit = gitP();
+
+         expect(git).not.toBeUndefined();
+      });
+   });
+
+   it('default export is the simple-git factory', async () => {
+      expect(await simpleGit().checkIsRepo()).toBe(true);
+   });
+
+   it('named type exports', async () => {
+      const git: SimpleGit = simpleGit();
+
+      expect(git).not.toBeUndefined();
+   });
+
+   it('named class constructors', async () => {
+      expect(new TaskConfigurationError('foo')).toBeInstanceOf(TaskConfigurationError);
+   });
+
+   it('named enums', async () => {
+      expect(CleanOptions.DRY_RUN).toBe('n');
+   });
+
+});

--- a/packages/test-typescript-esm-consumer/babel.config.js
+++ b/packages/test-typescript-esm-consumer/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@simple-git/babel-config')(true);

--- a/packages/test-typescript-esm-consumer/package.json
+++ b/packages/test-typescript-esm-consumer/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@simple-git/test-typescript-esm-consumer",
+  "private": true,
+  "version": "1.0.0",
+  "jest": {
+    "roots": [
+      "<rootDir>/test/"
+    ],
+    "testMatch": [
+      "**/test/*.spec.ts"
+    ]
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "@simple-git/babel-config": "^1.0.0",
+    "simple-git": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/steveukx/git-js.git",
+    "directory": "packages/test-typescript-consumer"
+  }
+}

--- a/packages/test-typescript-esm-consumer/test/ts-default-renamed-import.spec.ts
+++ b/packages/test-typescript-esm-consumer/test/ts-default-renamed-import.spec.ts
@@ -1,8 +1,8 @@
-import { simpleGit, CleanOptions, SimpleGit, TaskConfigurationError } from 'simple-git';
+import { default as simpleGit, CleanOptions, SimpleGit, TaskConfigurationError } from 'simple-git';
 
 describe('simple-git', () => {
 
-   describe('named export', () => {
+   describe('renamed default export', () => {
       it('is the simple-git factory', async () => {
          expect(await simpleGit().checkIsRepo()).toBe(true);
       });
@@ -12,6 +12,12 @@ describe('simple-git', () => {
 
          expect(git).not.toBeUndefined();
       });
+   });
+
+   it('named type exports', async () => {
+      const git: SimpleGit = simpleGit();
+
+      expect(git).not.toBeUndefined();
    });
 
    it('named class constructors', async () => {

--- a/packages/test-typescript-esm-consumer/test/ts-named-import.spec.ts
+++ b/packages/test-typescript-esm-consumer/test/ts-named-import.spec.ts
@@ -14,6 +14,12 @@ describe('simple-git', () => {
       });
    });
 
+   it('named type exports', async () => {
+      const git: SimpleGit = simpleGit();
+
+      expect(git).not.toBeUndefined();
+   });
+
    it('named class constructors', async () => {
       expect(new TaskConfigurationError('foo')).toBeInstanceOf(TaskConfigurationError);
    });

--- a/packages/test-typescript-esm-consumer/tsconfig.json
+++ b/packages/test-typescript-esm-consumer/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+//    "emitDecoratorMetadata": true,
+//    "experimentalDecorators": true,
+//    "forceConsistentCasingInFileNames": true,
+//    "incremental": true,
+//    "noFallthroughCasesInSwitch": false,
+//    "noImplicitAny": false,
+//    "outDir": "./dist",
+//    "removeComments": true,
+//    "skipLibCheck": true,
+//    "sourceMap": true,
+//    "strictBindCallApply": true,
+//    "strictNullChecks": false,
+  }
+}

--- a/simple-git/package.json
+++ b/simple-git/package.json
@@ -11,7 +11,7 @@
   ],
   "funding": {
     "type": "github",
-    "url": "https://github.com/sponsors/steveukx/"
+    "url": "https://github.com/steveukx/git-js?sponsor=1"
   },
   "dependencies": {
     "@kwsites/file-exists": "^1.1.1",

--- a/simple-git/readme.md
+++ b/simple-git/readme.md
@@ -30,14 +30,14 @@ const simpleGit = require('simple-git');
 simpleGit().clean(simpleGit.CleanOptions.FORCE);
 
 // or use named properties
-const {default: simpleGit, CleanOptions} = require('simple-git');
+const {simpleGit, CleanOptions} = require('simple-git');
 simpleGit().clean(CleanOptions.FORCE);
 ```
 
 Include into your JavaScript app as an ES Module:
 
 ```javascript
-import simpleGit, { CleanOptions } from 'simple-git';
+import { simpleGit, CleanOptions } from 'simple-git';
 
 simpleGit().clean(CleanOptions.FORCE);
 ```
@@ -45,7 +45,7 @@ simpleGit().clean(CleanOptions.FORCE);
 Include in a TypeScript app using the bundled type definitions:
 
 ```typescript
-import simpleGit, { SimpleGit, CleanOptions } from 'simple-git';
+import { simpleGit, SimpleGit, CleanOptions } from 'simple-git';
 
 const git: SimpleGit = simpleGit().clean(CleanOptions.FORCE);
 ```
@@ -55,7 +55,7 @@ const git: SimpleGit = simpleGit().clean(CleanOptions.FORCE);
 Configure each `simple-git` instance with a properties object passed to the main `simpleGit` function:
 
 ```typescript
-import simpleGit, { SimpleGit, SimpleGitOptions } from 'simple-git';
+import { simpleGit, SimpleGit, SimpleGitOptions } from 'simple-git';
 
 const options: Partial<SimpleGitOptions> = {
    baseDir: process.cwd(),
@@ -580,7 +580,7 @@ if (mergeSummary.failed) {
 With typed errors available in TypeScript
 
 ```typescript
-import simpleGit, { MergeSummary, GitResponseError } from 'simple-git';
+import { simpleGit, MergeSummary, GitResponseError } from 'simple-git';
 try {
   const mergeSummary = await simpleGit().merge();
   console.log(`Merged ${ mergeSummary.merges.length } files`);

--- a/simple-git/src/esm.mjs
+++ b/simple-git/src/esm.mjs
@@ -3,4 +3,6 @@ import { gitInstanceFactory } from './lib/git-factory';
 export {gitP} from './lib/runners/promise-wrapped';
 export * from './lib/api';
 
+export const simpleGit = gitInstanceFactory;
+
 export default gitInstanceFactory;

--- a/simple-git/src/index.js
+++ b/simple-git/src/index.js
@@ -2,6 +2,6 @@
 const {gitP} = require('./lib/runners/promise-wrapped');
 const {esModuleFactory, gitInstanceFactory, gitExportFactory} = require('./lib/git-factory');
 
-module.exports = esModuleFactory(
-   gitExportFactory(gitInstanceFactory, {gitP})
-);
+const simpleGit = esModuleFactory(gitExportFactory(gitInstanceFactory));
+
+module.exports = Object.assign(simpleGit, {gitP, simpleGit});

--- a/simple-git/src/lib/api.ts
+++ b/simple-git/src/lib/api.ts
@@ -21,16 +21,3 @@ export {
    TaskConfigurationError,
    grepQueryBuilder,
 };
-
-// export const api = {
-//    CheckRepoActions,
-//    CleanOptions,
-//    GitConfigScope,
-//    GitConstructError,
-//    GitError,
-//    GitPluginError,
-//    GitResponseError,
-//    ResetMode,
-//    TaskConfigurationError,
-//    grepQueryBuilder,
-// };

--- a/simple-git/src/lib/git-factory.ts
+++ b/simple-git/src/lib/git-factory.ts
@@ -22,20 +22,15 @@ const Git = require('../git');
  *
  * Eg: `module.exports = esModuleFactory({ something () {} })`
  */
-export function esModuleFactory<T>(defaultExport: T): T & { __esModule: true, default: T } {
+export function esModuleFactory<T>(defaultExport: T) {
    return Object.defineProperties(defaultExport, {
       __esModule: {value: true},
       default: {value: defaultExport},
-   });
+   }) as T & { __esModule: true, default: T };
 }
 
-export function gitExportFactory<T = {}>(factory: SimpleGitFactory, extra: T) {
-   return Object.assign(function (...args: Parameters<SimpleGitFactory>) {
-         return factory.apply(null, args);
-      },
-      api,
-      extra || {},
-   );
+export function gitExportFactory(factory: SimpleGitFactory) {
+   return Object.assign(factory.bind(null), api);
 }
 
 export function gitInstanceFactory(baseDir?: string | Partial<SimpleGitOptions>, options?: Partial<SimpleGitOptions>) {

--- a/simple-git/src/lib/plugins/completion-detection.plugin.ts
+++ b/simple-git/src/lib/plugins/completion-detection.plugin.ts
@@ -74,7 +74,7 @@ export function completionDetectionPlugin({
             close(events.exitCode);
          }
          catch (err) {
-            close(events.exitCode, err);
+            close(events.exitCode, err as Error);
          }
       }
    }

--- a/simple-git/src/lib/runners/git-executor-chain.ts
+++ b/simple-git/src/lib/runners/git-executor-chain.ts
@@ -62,7 +62,7 @@ export class GitExecutorChain implements SimpleGitExecutor {
                : this.attemptRemoteTask(task, logger)
          ) as R;
       } catch (e) {
-         throw this.onFatalException(task, e);
+         throw this.onFatalException(task, e as Error);
       } finally {
          onQueueComplete();
          onScheduleComplete();

--- a/simple-git/typings/index.d.ts
+++ b/simple-git/typings/index.d.ts
@@ -7,5 +7,6 @@ export * from './types';
 
 export declare const gitP: SimpleGitFactory;
 
-declare const simpleGit: SimpleGitFactory;
+export declare const simpleGit: SimpleGitFactory;
+
 export default simpleGit;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7834,10 +7834,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@4.7.4, typescript@^4.1.2:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 uglify-js@^3.1.4:
   version "3.14.5"


### PR DESCRIPTION
To enable support for ES modules in TypeScript >=4.7 (enabled with `module` and `moduleResolution` of `node16` or `nodenext` in the `tsconfig`), export `simpleGit` as a named export instead of as the default export from the `simple-git` package.

Add `simpleGit` to the TypeScript types while keeping default export for backward compatibility.

Closes #804 