### PR TITLE
feat(fetch) Add updated/deleted branches to fetch response.

### DIFF
--- a/.changeset/hip-ravens-smile.md
+++ b/.changeset/hip-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+"simple-git": patch
+---
+
+Added fields updated + deleted branch info to fetch response, closes [#823](https://github.com/steveukx/git-js/issues/823)

--- a/simple-git/src/lib/parsers/parse-fetch.ts
+++ b/simple-git/src/lib/parsers/parse-fetch.ts
@@ -5,18 +5,40 @@ const parsers: LineParser<FetchResult>[] = [
    new LineParser(/From (.+)$/, (result, [remote]) => {
       result.remote = remote;
    }),
-   new LineParser(/\* \[new branch]\s+(\S+)\s*-> (.+)$/, (result, [name, tracking]) =>{
-      result.branches.push({
-         name,
-         tracking,
+   new LineParser(
+      /\* \[new branch]\s+(\S+)\s*-> (.+)$/,
+      (result, [name, tracking]) => {
+         result.branches.push({
+            name,
+            tracking
+         });
+      }
+   ),
+   new LineParser(
+      /\* \[new tag]\s+(\S+)\s*-> (.+)$/,
+      (result, [name, tracking]) => {
+         result.tags.push({
+            name,
+            tracking
+         });
+      }
+   ),
+   new LineParser(/- \[deleted]\s+\S+\s*-> (.+)$/, (result, [tracking]) => {
+      result.deleted.push({
+         tracking
       });
    }),
-   new LineParser(/\* \[new tag]\s+(\S+)\s*-> (.+)$/, (result, [name, tracking]) => {
-      result.tags.push({
-         name,
-         tracking,
-      });
-   })
+   new LineParser(
+      /\s*([^.]+)\.\.(\S+)\s+(\S+)\s*-> (.+)$/,
+      (result, [from, to, name, tracking]) => {
+         result.updated.push({
+            name,
+            tracking,
+            to,
+            from
+         });
+      }
+   )
 ];
 
 export function parseFetchResult (stdOut: string, stdErr: string): FetchResult {
@@ -25,6 +47,8 @@ export function parseFetchResult (stdOut: string, stdErr: string): FetchResult {
       remote: null,
       branches: [],
       tags: [],
+      updated: [],
+      deleted: []
    };
    return parseStringResponse(result, parsers, [stdOut, stdErr]);
 }

--- a/simple-git/test/integration/fetch.spec.ts
+++ b/simple-git/test/integration/fetch.spec.ts
@@ -1,0 +1,93 @@
+// ./simple-git/test/integration/fetch.spec.ts
+
+import {
+   createTestContext,
+   newSimpleGit,
+   setUpInit,
+   SimpleGitTestContext
+} from '../__fixtures__';
+
+describe('fetch', () => {
+   let context: SimpleGitTestContext;
+   let upstream: string;
+   let local: string;
+
+   beforeEach(async () => (context = await createTestContext()));
+   beforeEach(async () => {
+      upstream = await context.dir('upstream');
+      local = context.path('local');
+      await context.file(['upstream', 'file']);
+
+      await givenRemote(upstream);
+      await givenLocal(upstream, local);
+   });
+
+   it('fetches updates', async () => {
+      const git = newSimpleGit(local);
+      const bravoPriorHead = await git.revparse('origin/bravo');
+      await givenRemoteChanges(upstream);
+
+      const result = await git.fetch(['--prune']);
+
+      const bravoCurrentHead = await git.revparse('origin/bravo');
+
+      expect(result).toEqual({
+         branches: [
+            {
+               name: 'delta',
+               tracking: 'origin/delta'
+            }
+         ],
+         deleted: [{ tracking: 'origin/charlie' }],
+         raw: '',
+         remote: upstream,
+         tags: [
+            {
+               name: 'alpha',
+               tracking: 'alpha'
+            }
+         ],
+         updated: [
+            {
+               from: bravoPriorHead.substring(0, 7),
+               name: 'bravo',
+               to: bravoCurrentHead.substring(0, 7),
+               tracking: 'origin/bravo'
+            }
+         ]
+      });
+   });
+
+   /**
+    * Sets up the repo to be used as a local - by cloning the remote
+    */
+   async function givenLocal(upstream: string, local: string) {
+      await newSimpleGit(context.root).clone(upstream, local);
+      await setUpInit({ git: newSimpleGit(local) });
+   }
+
+   /**
+    * Sets up the repo to be used as a remote
+    */
+   async function givenRemote(upstream: string) {
+      const git = newSimpleGit(upstream);
+      await setUpInit({ git });
+      await git.add('.');
+      await git.commit('first');
+      await git.raw('checkout', '-b', 'bravo');
+      await git.raw('checkout', '-b', 'charlie');
+   }
+   /**
+    * Configure the remote with changes to be retrieved when using fetch on the local
+    */
+   async function givenRemoteChanges(upstream: string) {
+      const git = newSimpleGit(upstream);
+      await git.raw('tag', 'alpha');
+      await git.raw('checkout', 'bravo');
+      await context.file(['upstream', 'another-file']);
+      await git.add('.');
+      await git.commit('second');
+      await git.raw('checkout', '-b', 'delta');
+      await git.raw('branch', '-d', 'charlie');
+   }
+});

--- a/simple-git/typings/response.d.ts
+++ b/simple-git/typings/response.d.ts
@@ -176,6 +176,15 @@ export interface FetchResult {
       name: string;
       tracking: string;
    }[];
+   updated: {
+      name: string;
+      tracking: string;
+      to: string;
+      from: string;
+   }[];
+   deleted: {
+      tracking: string;
+   }[];
 }
 
 /** Represents the response to git.grep */


### PR DESCRIPTION
Issue: https://github.com/steveukx/git-js/issues/823

Parses more of the git fetch response, notably updates + deletes.
This returns the to/from commit of each branch.
When `--prune` is passed, git will also return deleted branches.