### PR TITLE
Allow using just one of `from` and `to` in the `git.log` options.

### DIFF
--- a/.changeset/spotty-needles-leave.md
+++ b/.changeset/spotty-needles-leave.md
@@ -1,0 +1,5 @@
+---
+'simple-git': minor
+---
+
+Allow supplying just one of to/from in the options supplied to git.log

--- a/simple-git/readme.md
+++ b/simple-git/readme.md
@@ -295,14 +295,14 @@ For type details of the response for each of the tasks, please see the [TypeScri
 
    -  `options.file` - the path to a file in your repository to only consider this path.
    -  `options.format` - custom log format object, keys are the property names used on the returned object, values are the format string from [pretty formats](https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt)
-   -  `options.from` - when supplied along with `options.to` sets the range of commits to log
+   -  `options.from` - sets the oldest commit in the range to return, use along with `options.to` to set a bounded range
    -  `options.mailMap` - defaults to true, enables the use of [mail map](https://git-scm.com/docs/gitmailmap) in returned values for email and name from the default format
    -  `options.maxCount` - equivalent to setting the `--max-count` option
    -  `options.multiLine` - enables multiline body values in the default format (disabled by default)
    -  `options.splitter` - the character sequence to use as a delimiter between fields in the log, should be a value that doesn't appear in any log message (defaults to `ò`)
    -  `options.strictDate` - switches the authored date value from an ISO 8601-like format to be strict ISO 8601 format
    -  `options.symmetric` - defaults to true, enables [symmetric revision range](https://git-scm.com/docs/gitrevisions#_dotted_range_notations) rather than a two-dot range
-   -  `options.to` - when supplied along with `options.from` sets the range of commits to log
+   -  `options.to` - sets the newset commit in the range to return, use along with `options.from` to set a bounded range
 
 ## git merge
 

--- a/simple-git/src/lib/tasks/log.ts
+++ b/simple-git/src/lib/tasks/log.ts
@@ -120,9 +120,9 @@ export function parseLogOptions<T extends Options>(
       command.push(`--max-count=${maxCount}`);
    }
 
-   if (opt.from && opt.to) {
+   if (opt.from || opt.to) {
       const rangeOperator = opt.symmetric !== false ? '...' : '..';
-      suffix.push(`${opt.from}${rangeOperator}${opt.to}`);
+      suffix.push(`${opt.from || ''}${rangeOperator}${opt.to || ''}`);
    }
 
    if (filterString(opt.file)) {

--- a/simple-git/test/unit/log.spec.ts
+++ b/simple-git/test/unit/log.spec.ts
@@ -568,6 +568,22 @@ ${START_BOUNDARY}207601debebc170830f2921acf2b6b27034c3b1f::2016-01-03 15:50:58 +
          assertExecutedCommandsContains('--all');
       });
 
+      it.each([
+         [{ from: 'from' }, 'from...'],
+         [{ to: 'to' }, '...to'],
+         [{ from: 'from', to: '' }, 'from...'],
+         [{ from: '', to: 'to' }, '...to'],
+         [{ from: 'from', symmetric: true }, 'from...'],
+         [{ to: 'to', symmetric: true }, '...to'],
+         [{ from: 'from', symmetric: false }, 'from..'],
+         [{ to: 'to', symmetric: false }, '..to'],
+      ])(`supports partial with options %s`, async (options, result) => {
+         git.log(options);
+
+         await closeWithSuccess();
+         assertExecutedCommandsContains(result);
+      });
+
       it('when awaiting options object', async () => {
          const from = 'from-name';
          const to = 'to-name';


### PR DESCRIPTION
Closes #845