### PR TITLE
Fix typos

### DIFF
--- a/examples/git-version.md
+++ b/examples/git-version.md
@@ -1,7 +1,7 @@
-## Check if git is installed
+## Check if Git is installed
 
 To check if `git` (or the `customBinary` of your choosing) is accessible, use the
-`git.version()` api:
+`git.version()` API:
 
 ```typescript
 import { simpleGit } from 'simple-git';
@@ -11,10 +11,10 @@ if (!installed) {
   throw new Error(`Exit: "git" not available.`);
 }
 
-// ... continue using git commands here
+// ... continue using Git commands here
 ```
 
-## Check for a specific version of git
+## Check for a specific version of Git
 
 Using the `git.version()` interface, you can query for the current `git` version
 information split by `major`, `minor` and `patch`:
@@ -28,5 +28,5 @@ if (lt(String(versionResult), '2.1.0')) {
   throw new Error(`Exit: "git" must be at least version 2.1.0.`);
 }
 
-// ... continue using git commands here compatible with 2.1.0 or higher
+// ... continue using Git commands here that are compatible with 2.1.0 or higher
 ```


### PR DESCRIPTION
## Changes:

- Capitalize proper noun: Git.
- Capitalize abbreviation: API.

## Context:

Fixing up some typos in this file.