### PR TITLE
Block unsafe pack (push --exec)

### DIFF
--- a/.changeset/fair-cobras-arrive.md
+++ b/.changeset/fair-cobras-arrive.md
@@ -1,0 +1,5 @@
+---
+'simple-git': patch
+---
+
+Include restricting the use of git push --exec with other allowUnsafePack exclusions, thanks to @stsewd for the suggestion.

--- a/docs/PLUGIN-UNSAFE-ACTIONS.md
+++ b/docs/PLUGIN-UNSAFE-ACTIONS.md
@@ -6,6 +6,27 @@ that any parameter sourced from user input is validated before being passed to t
 In some cases where there is an elevated potential for harm `simple-git` will throw an exception unless you have
 explicitly opted in to the potentially unsafe action.
 
+### Enabling custom upload and receive packs
+
+Instead of using the default `git-receive-pack` and `git-upload-pack` binaries to parse incoming and outgoing
+data, `git` can be configured to use _any_ arbitrary binary or evaluable script.
+
+To avoid accidentally triggering the evaluation of a malicious script when merging user provided parameters
+into command executed by `simple-git`, custom pack options (usually with the `--receive-pack` and `--upload-pack`)
+are blocked without explicitly opting into their use  
+
+```typescript
+import { simpleGit } from 'simple-git';
+
+// throws
+await simpleGit()
+   .raw('push', '--receive-pack=git-receive-pack-custom');
+
+// allows calling clone with a helper transport
+await simpleGit({ unsafe: { allowUnsafePack: true } })
+   .raw('push', '--receive-pack=git-receive-pack-custom');
+```
+
 ### Overriding allowed protocols
 
 A standard installation of `git` permits `file`, `http` and `ssh` protocols for a remote. A range of 

--- a/simple-git/src/lib/plugins/block-unsafe-operations-plugin.ts
+++ b/simple-git/src/lib/plugins/block-unsafe-operations-plugin.ts
@@ -39,6 +39,14 @@ function preventUploadPack(arg: string, method: string) {
          `Use of clone with option -u is not permitted without enabling allowUnsafePack`
       );
    }
+
+   if (method === 'push' && /^\s*--exec\b/.test(arg)) {
+      throw new GitPluginError(
+         undefined,
+         'unsafe',
+         `Use of push with option --exec is not permitted without enabling allowUnsafePack`
+      );
+   }
 }
 
 export function blockUnsafeOperationsPlugin({

--- a/simple-git/test/unit/plugin.unsafe.spec.ts
+++ b/simple-git/test/unit/plugin.unsafe.spec.ts
@@ -8,9 +8,10 @@ import {
 
 describe('blockUnsafeOperationsPlugin', () => {
    it.each([
+      ['clone', '-u touch /tmp/pwn'],
       ['cmd', '--upload-pack=touch /tmp/pwn0'],
       ['cmd', '--receive-pack=touch /tmp/pwn1'],
-      ['clone', '-u touch /tmp/pwn'],
+      ['push', '--exec=touch /tmp/pwn2'],
    ])('allows %s %s only when using override', async (cmd, option) => {
       assertGitError(
          await promiseError(newSimpleGit({ unsafe: {} }).raw(cmd, option)),


### PR DESCRIPTION
Add `git push --exec` to the set of blocked operations without the use of an `allowUnsafePack` override.

/cc @stsewd