### PR TITLE
feat: add status to DiffResult

### DIFF
--- a/.changeset/silver-impalas-love.md
+++ b/.changeset/silver-impalas-love.md
@@ -1,0 +1,5 @@
+---
+'simple-git': minor
+---
+
+add status to DiffResult when using --name-status

--- a/simple-git/src/lib/parsers/parse-diff-summary.ts
+++ b/simple-git/src/lib/parsers/parse-diff-summary.ts
@@ -86,11 +86,12 @@ const nameOnlyParser = [
 ];
 
 const nameStatusParser = [
-   new LineParser<DiffResult>(/([ACDMRTUXB])\s*(.+)$/, (result, [_status, file]) => {
+   new LineParser<DiffResult>(/([ACDMRTUXB])\s*(.+)$/, (result, [status, file]) => {
       result.changed++;
       result.files.push({
          file,
          changes: 0,
+         status: status,
          insertions: 0,
          deletions: 0,
          binary: false,

--- a/simple-git/src/lib/parsers/parse-diff-summary.ts
+++ b/simple-git/src/lib/parsers/parse-diff-summary.ts
@@ -86,17 +86,20 @@ const nameOnlyParser = [
 ];
 
 const nameStatusParser = [
-   new LineParser<DiffResult>(/([ACDMRTUXB])\s*(.+)$/, (result, [status, file]) => {
-      result.changed++;
-      result.files.push({
-         file,
-         changes: 0,
-         status: status,
-         insertions: 0,
-         deletions: 0,
-         binary: false,
-      });
-   }),
+   new LineParser<DiffResult>(
+      /([ACDMRTUXB])([0-9][0-9][0-9])?\t(.[^\t]+)\t?(.*)?$/,
+      (result, [status, _similarity, from, to]) => {
+         result.changed++;
+         result.files.push({
+            file: to ?? from,
+            changes: 0,
+            status: status,
+            insertions: 0,
+            deletions: 0,
+            binary: false,
+         });
+      }
+   ),
 ];
 
 const diffSummaryParsers: Record<LogFormat, LineParser<DiffResult>[]> = {

--- a/simple-git/test/unit/diff.spec.ts
+++ b/simple-git/test/unit/diff.spec.ts
@@ -314,12 +314,12 @@ describe('diff', () => {
 
       it('diffSummary with --name-status', async () => {
          const task = git.diffSummary(['--name-status']);
-         await closeWithSuccess(`M       ${file}`);
+         await closeWithSuccess(`M\t${file}\nR100\tfrom\tto`);
 
          assertExecutedCommands('diff', '--name-status');
          expect(await task).toEqual(
             like({
-               changed: 1,
+               changed: 2,
                deletions: 0,
                insertions: 0,
                files: [
@@ -329,6 +329,14 @@ describe('diff', () => {
                      insertions: 0,
                      deletions: 0,
                      status: 'M',
+                     binary: false,
+                  },
+                  {
+                     file: 'to',
+                     changes: 0,
+                     insertions: 0,
+                     deletions: 0,
+                     status: 'R',
                      binary: false,
                   },
                ],

--- a/simple-git/test/unit/diff.spec.ts
+++ b/simple-git/test/unit/diff.spec.ts
@@ -328,6 +328,7 @@ describe('diff', () => {
                      changes: 0,
                      insertions: 0,
                      deletions: 0,
+                     status: 'M',
                      binary: false,
                   },
                ],

--- a/simple-git/typings/response.d.ts
+++ b/simple-git/typings/response.d.ts
@@ -142,7 +142,7 @@ export interface DiffResultTextFile {
    deletions: number;
    binary: false;
 
-   /** One of A|C|D|M|R|T|U|X|B. `--name-status` argument needed */
+   /** `--name-status` argument needed */
    status?: string;
 }
 
@@ -151,6 +151,9 @@ export interface DiffResultBinaryFile {
    before: number;
    after: number;
    binary: true;
+
+   /** `--name-status` argument needed */
+   status?: string;
 }
 
 export interface DiffResult {

--- a/simple-git/typings/response.d.ts
+++ b/simple-git/typings/response.d.ts
@@ -141,6 +141,9 @@ export interface DiffResultTextFile {
    insertions: number;
    deletions: number;
    binary: false;
+
+   /** One of A|C|D|M|R|T|U|X|B. `--name-status` argument needed */
+   status?: string;
 }
 
 export interface DiffResultBinaryFile {


### PR DESCRIPTION
Since #807 the parsing of `--name-status` is supported, but the file status is missing in the response. I've added it now as an optional property of `DiffResult`.