### PR TITLE
git.log should include a pathspec splitter automatically when using --follow

### DIFF
--- a/.changeset/sweet-steaks-draw.md
+++ b/.changeset/sweet-steaks-draw.md
@@ -1,0 +1,5 @@
+---
+'simple-git': minor
+---
+
+Use `pathspec` in `git.log` to allow use of previously deleted files in `file` argument

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
          matrix:
-            node-version: [14, 16, 18, 19]
+            node-version: [14, 16, 18, 20]
       steps:
          - uses: actions/checkout@v3
          - name: Use Node.js ${{ matrix.node-version }}

--- a/simple-git/src/lib/tasks/log.ts
+++ b/simple-git/src/lib/tasks/log.ts
@@ -1,6 +1,7 @@
 import type { Options, StringTask } from '../types';
 import type { LogResult, SimpleGit } from '../../../typings';
 import { logFormatFromCommand } from '../args/log-format';
+import { pathspec } from '../args/pathspec';
 import {
    COMMIT_BOUNDARY,
    createListLogSummaryParser,
@@ -126,7 +127,7 @@ export function parseLogOptions<T extends Options>(
    }
 
    if (filterString(opt.file)) {
-      suffix.push('--follow', opt.file);
+      command.push('--follow', pathspec(opt.file));
    }
 
    appendTaskOptions(userOptions(opt as Options), command);

--- a/simple-git/test/unit/log.spec.ts
+++ b/simple-git/test/unit/log.spec.ts
@@ -55,8 +55,8 @@ describe('log', () => {
          '--follow',
          '--fixed-strings',
          '--',
-         'file2',
-         'index.js'
+         'index.js',
+         'file2'
       );
    });
 


### PR DESCRIPTION
Switch to using a `pathspec` in `git.log` task to allow for the use of previously deleted files in the value of the `file` option.

Prior to this change users of `git.log` may have been explicitly appending `'--': null` to their `git.log` options argument, this is no longer required but should not cause any interruption if not removed from the calling code.

Closes #857