### PR TITLE
fix: stat diff summary performance

### DIFF
--- a/.changeset/six-cherries-grab.md
+++ b/.changeset/six-cherries-grab.md
@@ -1,0 +1,5 @@
+---
+"simple-git": patch
+---
+
+Fixed a performance issue when parsing stat diff summaries

--- a/simple-git/src/lib/parsers/parse-diff-summary.ts
+++ b/simple-git/src/lib/parsers/parse-diff-summary.ts
@@ -6,7 +6,7 @@ import { asNumber, LineParser, orVoid, parseStringResponse } from '../utils';
 
 const statParser = [
    new LineParser<DiffResult>(
-      /(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/,
+      /^(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/,
       (result, [file, changes, alterations = '']) => {
          result.files.push({
             file: file.trim(),
@@ -18,7 +18,7 @@ const statParser = [
       }
    ),
    new LineParser<DiffResult>(
-      /(.+) \|\s+Bin ([0-9.]+) -> ([0-9.]+) ([a-z]+)/,
+      /^(.+) \|\s+Bin ([0-9.]+) -> ([0-9.]+) ([a-z]+)/,
       (result, [file, before, after]) => {
          result.files.push({
             file: file.trim(),


### PR DESCRIPTION
While investigating why running git log was taking so long for a repo (it's pretty large and there was some mass renaming). There was one commit (~4000 changed files) that was taking ~19s to parse the diff summary for and overall it would take ~40s. When running the equivalent native git command it only took ~8s.

Looking into it a bit more, I believe the main cause was that the regex is doing a lot of backtracking, especially for long filenames. So my fix was to just add `^` to make it match from the start of the line and avoid some backtracking. In ou

**Before:**
```js
> run = async () => {
  const start = performance.now();
  await simpleGit().log({ '--stat': 4906 });
  console.log('Time', performance.now() - start);
}
> await run()
Time 40318.625875
```
**After:**
```js
> run = async () => {
  const start = performance.now();
  await simpleGit().log({ '--stat': 4906 });
  console.log('Time', performance.now() - start);
}
> await run()
Time 9392.257582999999
```