### PR TITLE
support full range of info available with --name-status

### DIFF
--- a/simple-git/src/lib/parsers/parse-diff-summary.ts
+++ b/simple-git/src/lib/parsers/parse-diff-summary.ts
@@ -88,11 +88,13 @@ const nameOnlyParser = [
 
 const nameStatusParser = [
    new LineParser<DiffResult>(
-      /([ACDMRTUXB])([0-9]{0,3})\t(.[^\t]*)(\t(.[^\t]*))?$/,
-      (result, [status, _similarity, from, _to, to]) => {
+      /([ACDMRTUXB])([0-9]{0,3})\t(.[^\t]*)(?:\t(.[^\t]*))?$/,
+      (result, [status, similarity, from, to]) => {
          result.changed++;
          result.files.push({
             file: to ?? from,
+            oldname: from,
+            similarity: similarity,
             changes: 0,
             status: orVoid(isDiffNameStatus(status) && status),
             insertions: 0,


### PR DESCRIPTION
when running with `--name-status` I really would like to see all the info available, this is why I am running with this option.

new properties returned are `oldname` and `similarity`.

the regular expression is improved by using a non-capturing group for the optional 4th element of the response