### PR TITLE
StatusSummary and FileStatusSummary bugfix

### DIFF
--- a/simple-git/src/lib/responses/FileStatusSummary.ts
+++ b/simple-git/src/lib/responses/FileStatusSummary.ts
@@ -10,7 +10,7 @@ export class FileStatusSummary implements FileStatusResult {
       public index: string,
       public working_dir: string
    ) {
-      if ('R' === index + working_dir) {
+      if (index === 'R' || working_dir === 'R') {
          const detail = fromPathRegex.exec(path) || [null, path, path];
          this.from = detail[1] || '';
          this.path = detail[2] || '';

--- a/simple-git/src/lib/responses/FileStatusSummary.ts
+++ b/simple-git/src/lib/responses/FileStatusSummary.ts
@@ -1,6 +1,6 @@
 import { FileStatusResult } from '../../../typings';
 
-export const fromPathRegex = /^(.+) -> (.+)$/;
+export const fromPathRegex = /^(.+)\0(.+)$/;
 
 export class FileStatusSummary implements FileStatusResult {
    public readonly from: string | undefined;
@@ -12,8 +12,8 @@ export class FileStatusSummary implements FileStatusResult {
    ) {
       if (index === 'R' || working_dir === 'R') {
          const detail = fromPathRegex.exec(path) || [null, path, path];
-         this.from = detail[1] || '';
-         this.path = detail[2] || '';
+         this.from = detail[2] || '';
+         this.path = detail[1] || '';
       }
    }
 }

--- a/simple-git/src/lib/responses/StatusSummary.ts
+++ b/simple-git/src/lib/responses/StatusSummary.ts
@@ -200,7 +200,7 @@ function splitLine(result: StatusResult, lineStr: string) {
       }
 
       if (raw !== '##' && raw !== '!!') {
-         result.files.push(new FileStatusSummary(path.replace(/\0.+$/, ''), index, workingDir));
+         result.files.push(new FileStatusSummary(path.replace(/\0([^\0]*)$/, ''), index, workingDir));
       }
    }
 }

--- a/simple-git/src/lib/responses/StatusSummary.ts
+++ b/simple-git/src/lib/responses/StatusSummary.ts
@@ -200,7 +200,7 @@ function splitLine(result: StatusResult, lineStr: string) {
       }
 
       if (raw !== '##' && raw !== '!!') {
-         result.files.push(new FileStatusSummary(path.replace(/\0([^\0]*)$/, ''), index, workingDir));
+         result.files.push(new FileStatusSummary(path, index, workingDir));
       }
    }
 }


### PR DESCRIPTION
Git status is called with the `--null` flag. This flag as well as `-z` changes the format of git status:
https://www.git-scm.com/docs/git-config/2.19.0#Documentation/git-config.txt--z
https://git-scm.com/docs/git-status#Documentation/git-status.txt--z

`FileStatusSummary` constructor has a bug with renames that is related to [this commit](https://github.com/steveukx/git-js/commit/ed412ef66994e3682854a692e114564669637a8d#diff-38151962bb09db21260f3d49f44559dc7a55191a0cd14216b872e15449bfaea7). The arrow is not printed inside the status, it is necessary to split with `\0`.

It seems unnecessary to me to delete `\0` before constructor inside `StatusSummary.ts`. But I might be wrong.

The following code:

```typescript
await git.add('file');
await git.commit('initial');
await git.mv('file', 'copy');
await git.add('copy');
```

caused this status **before**:

```
...
  "renamed": [
    {
      "from": "file",
      "to": "copy"
    }
  ],
  "files": [
    {
      "path": "copy",
      "index": "R",
      "working_dir": " "
    }
  ],
...
```

and this status **after**:
```
...
  "renamed": [
    {
      "from": "file",
      "to": "copy"
    }
  ],
  "files": [
    {
      "path": "copy",
      "index": "R",
      "working_dir": " ",
      "from": "file"
    }
  ],
...
```

