### PR TITLE
Git log parser

### DIFF
--- a/.changeset/brave-avocados-dress.md
+++ b/.changeset/brave-avocados-dress.md
@@ -1,0 +1,5 @@
+---
+'simple-git': patch
+---
+
+Resolve error in log parsing when fields have empty values.

--- a/simple-git/src/lib/parsers/parse-list-log-summary.ts
+++ b/simple-git/src/lib/parsers/parse-list-log-summary.ts
@@ -30,15 +30,12 @@ export function createListLogSummaryParser<T = any>(
 
    return function (stdOut: string): LogResult<T> {
       const all: ReadonlyArray<T & ListLogLine> = toLinesWithContent(
-         stdOut,
-         true,
+         stdOut.trim(),
+         false,
          START_BOUNDARY
       ).map(function (item) {
-         const lineDetail = item.trim().split(COMMIT_BOUNDARY);
-         const listLogLine: T & ListLogLine = lineBuilder(
-            lineDetail[0].trim().split(splitter),
-            fields
-         );
+         const lineDetail = item.split(COMMIT_BOUNDARY);
+         const listLogLine: T & ListLogLine = lineBuilder(lineDetail[0].split(splitter), fields);
 
          if (lineDetail.length > 1 && !!lineDetail[1].trim()) {
             listLogLine.diff = parseDiffResult(lineDetail[1]);

--- a/simple-git/test/unit/log.spec.ts
+++ b/simple-git/test/unit/log.spec.ts
@@ -401,6 +401,20 @@ ${START_BOUNDARY}ccc;;;;;2018-09-13 06:48:22 +0100;;;;;WIP on master: 2942035 bl
          );
       });
 
+      it('parses empty values', () => {
+         const parser = createListLogSummaryParser(SPLITTER, ['a', 'b']);
+         const actual = parser(`
+${START_BOUNDARY}f9ce27bb29e1a6971b7fdb7f19af6197be75061c${SPLITTER}ce55825${COMMIT_BOUNDARY}
+${START_BOUNDARY}ce55825e8dd96489be7bfedf456ac93c78fb3cfd${SPLITTER}${COMMIT_BOUNDARY}
+${START_BOUNDARY}${SPLITTER}${COMMIT_BOUNDARY}
+`);
+         expect(actual.all).toEqual([
+            { a: 'f9ce27bb29e1a6971b7fdb7f19af6197be75061c', b: 'ce55825' },
+            { a: 'ce55825e8dd96489be7bfedf456ac93c78fb3cfd', b: '' },
+            { a: '', b: '' },
+         ]);
+      });
+
       it('parses regular log', () => {
          const parser = createListLogSummaryParser(splitOn.PIPES, ['hash', 'message']);
          actual = parser(`


### PR DESCRIPTION
Resolve an issue when parsing the response to `git.log` that could leave part of the field separator in the preceding field.

The default splitter ` ò ` surrounds the character with spaces that were being trimmed through a needless use of `String#trim` in the parser.

Closes #985