### PR TITLE
Allow passing repeated flags to git commands

### DIFF
--- a/simple-git/src/lib/types/index.ts
+++ b/simple-git/src/lib/types/index.ts
@@ -17,7 +17,7 @@ export type TaskOptions<O extends Options = Options> = string[] | O;
 /**
  * Options supplied in most tasks as an optional trailing object
  */
-export type OptionsValues = null | string | number;
+export type OptionsValues = null | string | number | (string | number)[];
 export type Options = Record<string, OptionsValues>;
 
 export type OptionFlags<FLAGS extends string, VALUE = null> = Partial<Record<FLAGS, VALUE>>;

--- a/simple-git/src/lib/utils/task-options.ts
+++ b/simple-git/src/lib/utils/task-options.ts
@@ -24,6 +24,8 @@ export function appendTaskOptions<T extends Options = Options>(
          commands.push(value);
       } else if (filterPrimitives(value, ['boolean'])) {
          commands.push(key + '=' + value);
+      } else if (Array.isArray(value)) {
+         commands.push(...value.map((v) => key + '=' + v));
       } else {
          commands.push(key);
       }

--- a/simple-git/test/unit/push.spec.ts
+++ b/simple-git/test/unit/push.spec.ts
@@ -65,6 +65,13 @@ describe('push', () => {
          assertExecutedCommands('push', '--follow-tags', ...defaultCommands);
       });
 
+      it('git push with multiple --push-options', async () => {
+         git.push({ '--push-option': ["foo", "foo=bar", 123] });
+         await closeWithSuccess();
+
+         assertExecutedCommands('push', '--push-option=foo', '--push-option=foo=bar', '--push-option=123', ...defaultCommands);
+      });
+
       it('git push with remote/branch and options', async () => {
          git.push('rrr', 'bbb', { '--follow-tags': null });
          await closeWithSuccess();


### PR DESCRIPTION
This adds support repeated flags in `TaskOptions`. Example:

```ts
git.push({ '--push-option': ["foo", "foo=bar", 123] });
```

Which would result in the following command:

```console
git push --push-option=foo --push-option=foo=bar --push-option=123
```

Real use case: https://github.com/renovatebot/renovate/pull/35900#discussion_r2105849613
