### PR TITLE
fix: add 'shell' option to spawnOptions in SimpleGitPluginConfig

### DIFF
--- a/simple-git/src/lib/types/index.ts
+++ b/simple-git/src/lib/types/index.ts
@@ -127,7 +127,7 @@ export interface SimpleGitPluginConfig {
       stdOut?: boolean;
    };
 
-   spawnOptions: Pick<SpawnOptions, 'uid' | 'gid'>;
+   spawnOptions: Pick<SpawnOptions, 'uid' | 'gid' | 'shell'>;
 
    unsafe: {
       /**


### PR DESCRIPTION
add the `shell: true` option to the spawnOptions in the ctor config.
this will allow using wildcards in path values, which will be transferred as-is to the underlying spawned process.

fixes #1055