### PR TITLE
fix: remove explicit node:buffer import

### DIFF
--- a/.changeset/rotten-chicken-fetch.md
+++ b/.changeset/rotten-chicken-fetch.md
@@ -1,0 +1,5 @@
+---
+'simple-git': patch
+---
+
+Remove conflicting node:buffer import

--- a/simple-git/src/lib/utils/util.ts
+++ b/simple-git/src/lib/utils/util.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'node:buffer';
 import { exists, FOLDER } from '@kwsites/file-exists';
 import type { Maybe } from '../types';
 import { filterHasLength } from './argument-filters';


### PR DESCRIPTION
I'm using this package in the [Git plugin](https://github.com/Vinzent03/obsidian-git) for [Obsidian.md](https://obsidian.md). It needs also be able to run on mobile without node (where I use another package for git instead).

With the new version of simple-git and #1049 this import was added. This causes my plugin building using esbuild and the `platform` set to `browser` (instead of `node` which would work for desktop only where node is indeed available) to fail. By removing this explicit node import, everything seems to work great again.