### PR TITLE
Remove on exit

### DIFF
--- a/simple-git/src/lib/plugins/timout-plugin.ts
+++ b/simple-git/src/lib/plugins/timout-plugin.ts
@@ -22,7 +22,6 @@ export function timeoutPlugin({
             function stop() {
                context.spawned.stdout?.off('data', wait);
                context.spawned.stderr?.off('data', wait);
-               context.spawned.off('exit', stop);
                context.spawned.off('close', stop);
                timeout && clearTimeout(timeout);
             }
@@ -34,7 +33,6 @@ export function timeoutPlugin({
 
             stdOut && context.spawned.stdout?.on('data', wait);
             stdErr && context.spawned.stderr?.on('data', wait);
-            context.spawned.on('exit', stop);
             context.spawned.on('close', stop);
 
             wait();

--- a/simple-git/test/integration/plugin.progress.spec.ts
+++ b/simple-git/test/integration/plugin.progress.spec.ts
@@ -33,7 +33,7 @@ describe('progress-monitor', () => {
          expect(update.progress).toBeGreaterThanOrEqual(previous);
          return update.progress;
       }, 0);
-   });
+   }, 10000);
 });
 
 function progressEventsAtStage(mock: jest.Mock, stage: string) {

--- a/simple-git/test/unit/__fixtures__/child-processes.ts
+++ b/simple-git/test/unit/__fixtures__/child-processes.ts
@@ -12,7 +12,7 @@ export async function writeToStdErr(data = '') {
       throw new Error(`writeToStdErr unable to find matching child process`);
    }
 
-   if (proc.$emitted('exit')) {
+   if (proc.$emitted('close')) {
       throw new Error('writeToStdErr: attempting to write to an already closed process');
    }
 
@@ -27,7 +27,7 @@ export async function writeToStdOut(data = '') {
       throw new Error(`writeToStdOut unable to find matching child process`);
    }
 
-   if (proc.$emitted('exit')) {
+   if (proc.$emitted('close')) {
       throw new Error('writeToStdOut: attempting to write to an already closed process');
    }
 
@@ -45,7 +45,7 @@ export async function closeWithError(stack = 'CLOSING WITH ERROR', code = EXIT_C
 
 export async function closeWithSuccess(message = '') {
    await wait();
-   const match = mockChildProcessModule.$matchingChildProcess((p) => !p.$emitted('exit'));
+   const match = mockChildProcessModule.$matchingChildProcess((p) => !p.$emitted('close'));
    if (!match) {
       throw new Error(`closeWithSuccess unable to find matching child process`);
    }
@@ -82,15 +82,14 @@ export function theChildProcessMatching(what: string[] | ((mock: MockChildProces
 }
 
 async function exitChildProcess(proc: MockChildProcess, data: string | null, exitSignal: number) {
-   if (proc.$emitted('exit')) {
-      throw new Error('exitChildProcess: attempting to exit an already closed process');
+   if (proc.$emitted('close')) {
+      throw new Error('exitChildProcess: attempting to close an already closed process');
    }
 
    if (typeof data === 'string') {
       proc.stdout.$emit('data', Buffer.from(data));
    }
 
-   // exit/close events are bound to the process itself
-   proc.$emit('exit', exitSignal);
+   // close event is bound to the process itself
    proc.$emit('close', exitSignal);
 }

--- a/simple-git/test/unit/__mocks__/mock-child-process.ts
+++ b/simple-git/test/unit/__mocks__/mock-child-process.ts
@@ -33,11 +33,10 @@ class MockEventTargetImpl implements MockEventTarget {
    };
 
    public kill = jest.fn((_signal = 'SIGINT') => {
-      if (this.$emitted('exit')) {
+      if (this.$emitted('close')) {
          throw new Error('MockEventTarget:kill called on process after exit');
       }
 
-      this.$emit('exit', 1);
       this.$emit('close', 1);
    });
 

--- a/simple-git/test/unit/git-executor.spec.ts
+++ b/simple-git/test/unit/git-executor.spec.ts
@@ -13,7 +13,7 @@ async function withStdErr() {
 }
 
 async function childProcessEmits(
-   event: 'close' | 'exit',
+   event: 'close',
    code: number,
    before?: () => Promise<void>
 ) {
@@ -57,27 +57,10 @@ describe('git-executor', () => {
       await thenTheTaskHasCompleted();
    });
 
-   it('with no stdErr and just an exit event, terminates after a delay', async () => {
-      givenTheTaskIsAdded();
-
-      await childProcessEmits('exit', 0);
-      await thenTheTaskHasNotCompleted();
-
-      await aWhile();
-      await thenTheTaskHasCompleted();
-   });
-
    it('with stdErr and just a close event, terminates immediately', async () => {
       givenTheTaskIsAdded();
 
       await childProcessEmits('close', 0, withStdErr);
-      await thenTheTaskHasCompleted();
-   });
-
-   it('with stdErr and just an exit event, terminates immediately', async () => {
-      givenTheTaskIsAdded();
-
-      await childProcessEmits('exit', 0, withStdErr);
       await thenTheTaskHasCompleted();
    });
 
@@ -88,25 +71,10 @@ describe('git-executor', () => {
       await thenTheTaskHasCompleted();
    });
 
-   it('with stdOut and just an exit event, terminates immediately', async () => {
-      givenTheTaskIsAdded();
-
-      await childProcessEmits('exit', 0, withStdOut);
-      await thenTheTaskHasCompleted();
-   });
-
-   it('with both cancel and exit events, only terminates once', async () => {
+   it('with 2 close events, only terminates once', async () => {
       givenTheTaskIsAdded();
 
       await childProcessEmits('close', 0);
-      await childProcessEmits('exit', 0);
-      await thenTheTaskHasCompleted();
-   });
-
-   it('with both exit and cancel events, only terminates once', async () => {
-      givenTheTaskIsAdded();
-
-      await childProcessEmits('exit', 0);
       await childProcessEmits('close', 0);
       await thenTheTaskHasCompleted();
    });

--- a/simple-git/test/unit/plugins/plugin.completion-detection.spec.ts
+++ b/simple-git/test/unit/plugins/plugin.completion-detection.spec.ts
@@ -2,13 +2,12 @@ import { newSimpleGit, theChildProcessMatching, wait } from '../__fixtures__';
 import { MockChildProcess } from '../__mocks__/mock-child-process';
 
 describe('completionDetectionPlugin', () => {
-   function process(proc: MockChildProcess, data: string, close = false, exit = false) {
+   function process(proc: MockChildProcess, data: string, close = false) {
       proc.stdout.$emit('data', Buffer.from(data));
       close && proc.$emit('close', 1);
-      exit && proc.$emit('exit', 1);
    }
 
-   it('can respond to just close events', async () => {
+   it('can respond to close events', async () => {
       const git = newSimpleGit({
          completion: {
             onClose: true,
@@ -20,27 +19,9 @@ describe('completionDetectionPlugin', () => {
 
       await wait();
 
-      process(theChildProcessMatching(['foo']), 'foo', false, true);
-      process(theChildProcessMatching(['bar']), 'bar', true, false);
+      process(theChildProcessMatching(['foo']), 'foo', false);
+      process(theChildProcessMatching(['bar']), 'bar', true);
 
       expect(await output).toBe('bar');
-   });
-
-   it('can respond to just exit events', async () => {
-      const git = newSimpleGit({
-         completion: {
-            onClose: false,
-            onExit: true,
-         },
-      });
-
-      const output = Promise.race([git.raw('foo'), git.raw('bar')]);
-
-      await wait();
-
-      process(theChildProcessMatching(['foo']), 'foo', false, true);
-      process(theChildProcessMatching(['bar']), 'bar', true, false);
-
-      expect(await output).toBe('foo');
    });
 });


### PR DESCRIPTION
Hi Steve! Thanks for making such an excellent project.

We have been encountering an issue with git-js in our environment. Our Salesforce team is using git-js through another package sfdx-git-delta which is a git based diff tool for packaging Salesforce projects. 

The issue we're encountering is that occasionally, under heavy and concurrent load, SGD receives an incomplete file from git-js. This is due to the fact that git-js listens to the exit event and will return early from the git show command thereby chopping off the end of the file.

This PR removes the exit listener altogether and that fixes our issue. I see in the completion plugin docs that you were planning on turning off the exit listener at some point but maybe decided not to. Are you happy with the idea of removing the exit listener altogether? Nodejs docs say close happens after exit and that it happens after stdout & stderr are closed.