### PR TITLE
Fix backward compatibility

### DIFF
--- a/.changeset/early-lies-check.md
+++ b/.changeset/early-lies-check.md
@@ -1,0 +1,5 @@
+---
+"@simple-git/argv-parser": minor
+---
+
+Add backward compatible API, resolves issue caused by using simple-git@3.35.2 with @simple-git/argv-parser@1.1.0

--- a/.changeset/early-lies-check.md
+++ b/.changeset/early-lies-check.md
@@ -1,5 +1,5 @@
 ---
-"@simple-git/argv-parser": minor
+"@simple-git/argv-parser": patch
 ---
 
 Add backward compatible API, resolves issue caused by using simple-git@3.35.2 with @simple-git/argv-parser@1.1.0

--- a/packages/argv-parser/src/args/parse-argv.ts
+++ b/packages/argv-parser/src/args/parse-argv.ts
@@ -2,6 +2,7 @@ import { collectConfigAccess } from '../config/analyse-config';
 import type { Flag } from '../flags/flags.helpers';
 import { parseGlobalFlags } from '../flags/parse-global-flags';
 import { parseTaskFlags } from '../flags/parse-task-flags';
+import type { Vulnerability } from '../vulnerabilities/vulnerability.types';
 import { vulnerabilityAnalysis } from '../vulnerabilities/vulnerability-analysis';
 import type { ParsedArgv, ParsedFlag } from './parse-argv.types';
 
@@ -23,8 +24,14 @@ export function parseArgv(...tokens: readonly unknown[]): ParsedArgv {
       flags: flags.map(toParsedFlag),
       paths: pathspecs,
       config,
-      vulnerabilities: vulnerabilityAnalysis(task, flags, config),
+      vulnerabilities: vulnerabilityList(vulnerabilityAnalysis(task, flags, config)),
    };
+}
+
+function vulnerabilityList(vulnerabilities: Vulnerability[]) {
+   return Object.defineProperty(vulnerabilities, 'vulnerabilities', {
+      value: vulnerabilities,
+   });
 }
 
 function toParsedFlag({ value, name }: Flag): ParsedFlag {


### PR DESCRIPTION
Reinstate `parseArgv().vulnerabilities.vulnerabilities` API to resolves issue caused by using simple-git@3.35.2 with @simple-git/argv-parser@1.1.0.

Introduced in #1156 