### PR TITLE
Add support for one-shot stdin via `.input()`

### DIFF
--- a/.changeset/calm-birds-listen.md
+++ b/.changeset/calm-birds-listen.md
@@ -1,0 +1,5 @@
+---
+"simple-git": minor
+---
+
+Support one-shot stdin via `git.input(data)` (`string` or `Buffer`).

--- a/simple-git/CHANGELOG.md
+++ b/simple-git/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change History & Release Notes
 
+## Unreleased
+
+### Minor Changes
+
+- Support one-shot stdin via `git.input(data)` (`string` or `Buffer`).
+
 ## 3.36.0
 
 ### Minor Changes

--- a/simple-git/readme.md
+++ b/simple-git/readme.md
@@ -199,6 +199,7 @@ in v2 (deprecation notices were logged to `stdout` as `console.warn` in v2).
 | `.commit(message, [fileA, ...], options, handlerFn)` | commits changes on the named files with the supplied message, when supplied, the optional options object can contain any other parameters to pass to the commit command, setting the value of the property to be a string will add `name=value` to the command string, setting any other type of value will result in just the key from the object being passed (ie: just `name`), an example of setting the author is below |
 | `.customBinary(gitPath)`                             | sets the command to use to reference git, allows for using a git binary not available on the path environment variable [docs](https://github.com/steveukx/git-js/blob/main/docs/PLUGIN-CUSTOM-BINARY.md)                                                                                                                                                                                                                     |
 | `.env(name, value)`                                  | Set environment variables to be passed to the spawned child processes, [see usage in detail below](#environment-variables).                                                                                                                                                                                                                                                                                                  |
+| `.input(data)`                                       | Write a `string` or `Buffer` to stdin of the next git command (one-shot). See [Stdin](#stdin).                                                                                                                                                                                                                                                                                                                                |
 | `.exec(handlerFn)`                                   | calls a simple function in the current step                                                                                                                                                                                                                                                                                                                                                                                  |
 | `.fetch([options, ] handlerFn)`                      | update the local working copy database with changes from the default remote repo and branch, when supplied the options argument can be a standard [options object](#how-to-specify-options) either an array of string commands as supported by the [git fetch](https://git-scm.com/docs/git-fetch).                                                                                                                          |
 | `.fetch(remote, branch, handlerFn)`                  | update the local working copy database with changes from a remote repo                                                                                                                                                                                                                                                                                                                                                       |
@@ -545,6 +546,17 @@ simpleGit()
 
 Be sure to not enable debug logging when using this mechanism for authentication
 to ensure passwords aren't logged to stdout.
+
+# Stdin
+
+Some git commands read stdin (e.g. `interpret-trailers --parse`,
+`hash-object --stdin`). Supply a one-shot `string` or `Buffer` with `.input()`:
+
+```js
+const trailers = await simpleGit()
+   .input(commitMessage)
+   .raw(['interpret-trailers', '--parse']);
+```
 
 # Environment Variables
 

--- a/simple-git/src/git.js
+++ b/simple-git/src/git.js
@@ -88,6 +88,21 @@ Git.prototype.env = function (name, value) {
 };
 
 /**
+ * One-shot stdin (`string`|`Buffer`) for the next spawned git command.
+ * Call with no args to clear. @param {string|Buffer} [data]
+ */
+Git.prototype.input = function (data) {
+   if (arguments.length === 0) {
+      this._executor.pendingInput = undefined;
+   } else if (typeof data !== 'string' && !Buffer.isBuffer(data)) {
+      throw new TypeError('git.input: data must be a string or Buffer');
+   } else {
+      this._executor.pendingInput = data;
+   }
+   return this;
+};
+
+/**
  * List the stash(s) of the local repo
  */
 Git.prototype.stashList = function (options) {

--- a/simple-git/src/lib/runners/git-executor-chain.ts
+++ b/simple-git/src/lib/runners/git-executor-chain.ts
@@ -20,6 +20,8 @@ export class GitExecutorChain implements SimpleGitExecutor {
    private _queue = new TasksPendingQueue();
    private _cwd: string | undefined;
 
+   public pendingInput?: string | Buffer;
+
    public get cwd() {
       return this._cwd || this._executor.cwd;
    }
@@ -47,6 +49,11 @@ export class GitExecutorChain implements SimpleGitExecutor {
    }
 
    public push<R>(task: SimpleGitTask<R>): Promise<R> {
+      if (!isEmptyTask(task) && this.pendingInput !== undefined) {
+         (task as RunnableTask<R>).input = this.pendingInput;
+         this.pendingInput = undefined;
+      }
+
       this._queue.push(task);
 
       return (this._chain = this._chain.then(() => this.attemptTask(task)));
@@ -166,7 +173,7 @@ export class GitExecutorChain implements SimpleGitExecutor {
    }
 
    private async gitResponse<R>(
-      task: SimpleGitTask<R>,
+      task: RunnableTask<R>,
       command: string,
       args: string[],
       outputHandler: Maybe<outputHandler>,
@@ -219,6 +226,20 @@ export class GitExecutorChain implements SimpleGitExecutor {
          );
 
          spawned.on('error', onErrorReceived(stdErr, logger));
+
+         if (task.input !== undefined && spawned.stdin) {
+            logger(
+               `writing %s bytes to stdin`,
+               Buffer.isBuffer(task.input) ? task.input.length : Buffer.byteLength(task.input)
+            );
+            spawned.stdin.on('error', (err: NodeJS.ErrnoException) => {
+               // EPIPE is expected when git exits before consuming all input
+               if (err.code !== 'EPIPE') {
+                  logger('[ERROR] stdin error %o', err);
+               }
+            });
+            spawned.stdin.end(task.input);
+         }
 
          if (outputHandler) {
             logger(`Passing child process stdOut/stdErr to custom outputHandler`);

--- a/simple-git/src/lib/runners/git-executor.ts
+++ b/simple-git/src/lib/runners/git-executor.ts
@@ -9,6 +9,7 @@ export class GitExecutor implements SimpleGitExecutor {
 
    public env: GitExecutorEnv;
    public outputHandler?: outputHandler;
+   public pendingInput?: string | Buffer;
 
    constructor(
       public cwd: string,
@@ -17,7 +18,10 @@ export class GitExecutor implements SimpleGitExecutor {
    ) {}
 
    chain(): SimpleGitExecutor {
-      return new GitExecutorChain(this, this._scheduler, this._plugins);
+      const chained = new GitExecutorChain(this, this._scheduler, this._plugins);
+      chained.pendingInput = this.pendingInput;
+      this.pendingInput = undefined;
+      return chained;
    }
 
    push<R>(task: SimpleGitTask<R>): Promise<R> {

--- a/simple-git/src/lib/types/index.ts
+++ b/simple-git/src/lib/types/index.ts
@@ -47,6 +47,7 @@ export interface SimpleGitExecutor {
    env: GitExecutorEnv;
    outputHandler?: outputHandler;
    cwd: string;
+   pendingInput?: string | Buffer;
 
    chain(): SimpleGitExecutor;
 

--- a/simple-git/src/lib/types/tasks.ts
+++ b/simple-git/src/lib/types/tasks.ts
@@ -15,6 +15,7 @@ export interface SimpleGitTaskConfiguration<RESPONSE, FORMAT, INPUT extends Task
    commands: string[];
    format: FORMAT;
    parser: TaskParser<INPUT, RESPONSE>;
+   input?: string | Buffer;
 
    onError?: (
       result: GitExecutorResult,

--- a/simple-git/test/integration/input.spec.ts
+++ b/simple-git/test/integration/input.spec.ts
@@ -1,0 +1,30 @@
+import { createTestContext, newSimpleGit, SimpleGitTestContext } from '@simple-git/test-utils';
+
+describe('input', () => {
+   let context: SimpleGitTestContext;
+
+   beforeEach(async () => {
+      context = await createTestContext();
+      await newSimpleGit(context.root).init();
+   });
+
+   it('feeds stdin to interpret-trailers --parse', async () => {
+      const message = ['Fix bug', '', 'Signed-off-by: Test User <test@example.com>'].join('\n');
+      const out = await newSimpleGit(context.root)
+         .input(message)
+         .raw(['interpret-trailers', '--parse']);
+      expect(out).toContain('Signed-off-by: Test User <test@example.com>');
+   });
+
+   it('feeds stdin to hash-object --stdin', async () => {
+      const hash = await newSimpleGit(context.root).input('hello\n').raw(['hash-object', '--stdin']);
+      expect(hash.trim()).toBe('ce013625030ba8dba906f756967f9e9ca394464a');
+   });
+
+   it('succeeds when git ignores supplied stdin', async () => {
+      const inside = await newSimpleGit(context.root)
+         .input('ignored')
+         .raw(['rev-parse', '--is-inside-work-tree']);
+      expect(inside.trim()).toBe('true');
+   });
+});

--- a/simple-git/test/unit/__mocks__/mock-child-process.ts
+++ b/simple-git/test/unit/__mocks__/mock-child-process.ts
@@ -13,6 +13,7 @@ export type MockChildProcess = MockEventTarget & {
 
    readonly stderr: MockEventTarget;
    readonly stdout: MockEventTarget;
+   readonly stdin: MockEventTarget & { end: jest.Mock };
 
    kill(): void;
 };
@@ -96,6 +97,9 @@ class MockChildProcessImpl extends MockEventTargetImpl implements MockChildProce
 
    public readonly stderr = new MockEventTargetImpl();
    public readonly stdout = new MockEventTargetImpl();
+   public readonly stdin = Object.assign(new MockEventTargetImpl(), {
+      end: jest.fn(),
+   });
 
    constructor(private constructedWith: ChildProcessConstructor) {
       super();

--- a/simple-git/test/unit/input.spec.ts
+++ b/simple-git/test/unit/input.spec.ts
@@ -1,0 +1,106 @@
+import { promiseError } from '@kwsites/promise-result';
+import {
+   closeWithSuccess,
+   isInvalidDirectory,
+   newSimpleGit,
+   theChildProcessMatching,
+   wait,
+} from './__fixtures__';
+import { SimpleGit } from '../../typings';
+import { mockChildProcessModule as childProcess } from './__mocks__/mock-child-process';
+
+describe('input', () => {
+   let git: SimpleGit;
+
+   beforeEach(() => {
+      git = newSimpleGit();
+   });
+
+   it('does not write stdin when unset', async () => {
+      const task = git.raw(['status']);
+      await closeWithSuccess();
+      await task;
+      expect(childProcess.$mostRecent().stdin.end).not.toHaveBeenCalled();
+   });
+
+   it('writes string or Buffer to the next command only', async () => {
+      const buf = Buffer.from('bin');
+      const withString = git.input('hello').raw(['a']);
+      await closeWithSuccess();
+      await withString;
+      expect(childProcess.$matchingChildProcess(['a'])!.stdin.end).toHaveBeenCalledWith('hello');
+
+      const withBuf = git.input(buf).raw(['b']);
+      await closeWithSuccess();
+      await withBuf;
+      expect(childProcess.$matchingChildProcess(['b'])!.stdin.end).toHaveBeenCalledWith(buf);
+
+      const third = git.raw(['c']);
+      await closeWithSuccess();
+      await third;
+      expect(childProcess.$matchingChildProcess(['c'])!.stdin.end).not.toHaveBeenCalled();
+   });
+
+   it('skips empty tasks and supports mid-chain input', async () => {
+      const task = git
+         .input('first')
+         .exec(() => {})
+         .raw(['a'])
+         .input('second')
+         .raw(['b']);
+
+      await wait();
+      await theChildProcessMatching(['a']).closeWithSuccess();
+      await wait();
+      await theChildProcessMatching(['b']).closeWithSuccess();
+      await task;
+
+      expect(childProcess.$matchingChildProcess(['a'])!.stdin.end).toHaveBeenCalledWith('first');
+      expect(childProcess.$matchingChildProcess(['b'])!.stdin.end).toHaveBeenCalledWith('second');
+   });
+
+   it('rejects invalid types and clears with zero args', async () => {
+      expect(() => git.input(1 as any)).toThrow(TypeError);
+
+      const cleared = git.input('secret').input().raw(['status']);
+      await closeWithSuccess();
+      await cleared;
+      expect(childProcess.$mostRecent().stdin.end).not.toHaveBeenCalled();
+
+      const empty = git.input('').raw(['status']);
+      await closeWithSuccess();
+      await empty;
+      expect(childProcess.$mostRecent().stdin.end).toHaveBeenCalledWith('');
+   });
+
+   it('keeps concurrent fluent inputs isolated', async () => {
+      const pA = git.input('alpha').raw(['cmdA']);
+      const pB = git.input('beta').raw(['cmdB']);
+      await wait();
+      await theChildProcessMatching(['cmdA']).closeWithSuccess();
+      await theChildProcessMatching(['cmdB']).closeWithSuccess();
+      await Promise.all([pA, pB]);
+
+      expect(childProcess.$matchingChildProcess(['cmdA'])!.stdin.end).toHaveBeenCalledWith('alpha');
+      expect(childProcess.$matchingChildProcess(['cmdB'])!.stdin.end).toHaveBeenCalledWith('beta');
+   });
+
+   it('does not leak after a failed empty task', async () => {
+      isInvalidDirectory();
+      await expect(promiseError(git.input('secret').cwd('/nope'))).resolves.toBeInstanceOf(Error);
+
+      require('@kwsites/file-exists').exists.mockReturnValue(true);
+      const next = git.raw(['status']);
+      await closeWithSuccess();
+      await next;
+      expect(childProcess.$mostRecent().stdin.end).not.toHaveBeenCalled();
+   });
+
+   it('ignores stdin stream errors', async () => {
+      const task = git.input('data').raw(['status']);
+      await wait();
+      childProcess.$mostRecent().stdin.$emit('error', { code: 'EPIPE' });
+      await closeWithSuccess('ok');
+      await expect(task).resolves.toBe('ok');
+   });
+});

--- a/simple-git/typings/simple-git.d.ts
+++ b/simple-git/typings/simple-git.d.ts
@@ -536,6 +536,12 @@ export interface SimpleGit extends SimpleGitBase {
 
    env(env: object): this;
 
+   /** One-shot stdin for the next spawned git command. */
+   input(data: string | Buffer): this;
+
+   /** Clear pending stdin. */
+   input(): this;
+
    /**
     * Calls the supplied `handle` function at the next step in the chain, used to run arbitrary functions synchronously
     * before the next task in the git API.


### PR DESCRIPTION
This allows passing stdin for git commands like:

```js
const trailers = await simpleGit()
   .input(commitMessage)
   .raw(['interpret-trailers', '--parse']);
```

Useful for commands like `interpret-trailers --parse` and `hash-object --stdin`.

Related:

- #332
- #1046

I realized this limitation when working on https://github.com/renovatebot/renovate/pull/44651, where I needed to call `echo "commit message" | git interpret-trailers --parse`.

So I thought this would be a nice and simple way to fix it, while still having room for future improvements like support for `Stream`s.