### PR TITLE
fix: parse binary rename diff stats

### DIFF
--- a/.changeset/tiny-diffs-smile.md
+++ b/.changeset/tiny-diffs-smile.md
@@ -1,0 +1,5 @@
+---
+'simple-git': patch
+---
+
+Parse binary rename entries without byte counts in diff summaries.

--- a/simple-git/src/lib/parsers/parse-diff-summary.ts
+++ b/simple-git/src/lib/parsers/parse-diff-summary.ts
@@ -28,6 +28,14 @@ const statParser = [
          });
       }
    ),
+   new LineParser<DiffResult>(/^(.+)\s+\|\s+Bin\s*$/, (result, [file]) => {
+      result.files.push({
+         file: file.trim(),
+         before: 0,
+         after: 0,
+         binary: true,
+      });
+   }),
    new LineParser<DiffResult>(
       /(\d+) files? changed\s*((?:, \d+ [^,]+){0,2})/,
       (result, [changed, summary]) => {

--- a/simple-git/test/integration/diff.spec.ts
+++ b/simple-git/test/integration/diff.spec.ts
@@ -67,3 +67,34 @@ describe('diff', function () {
       );
    });
 });
+
+describe('diff binary files', function () {
+   let context: SimpleGitTestContext;
+
+   beforeEach(async () => {
+      context = await createTestContext();
+      await setUpInit(context);
+   });
+
+   it('detects renamed binary files', async () => {
+      const git = newSimpleGit(context.root);
+      const original = 'uploads/image.png';
+      const renamed = 'uploads/image-test.png';
+
+      await context.file(['uploads', 'image.png'], '\0binary image content');
+      await git.add(original).commit('add binary file');
+      const beforeRename = await git.revparse('HEAD');
+
+      await git.mv(original, renamed).commit('rename binary file');
+      const diff = await git.diffSummary([beforeRename, 'HEAD']);
+
+      expect(diff.files).toEqual([
+         {
+            file: 'uploads/{image.png => image-test.png}',
+            before: 0,
+            after: 0,
+            binary: true,
+         },
+      ]);
+   });
+});

--- a/simple-git/test/unit/diff.spec.ts
+++ b/simple-git/test/unit/diff.spec.ts
@@ -38,6 +38,27 @@ describe('diff', () => {
          );
       });
 
+      it('bin summary without byte counts', () => {
+         const summary = getDiffParser(LogFormat.STAT)(`
+ uploads/{image.png => image-test.png} | Bin
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ `);
+         expect(summary).toEqual(
+            like({
+               insertions: 0,
+               deletions: 0,
+               files: [
+                  {
+                     file: 'uploads/{image.png => image-test.png}',
+                     before: 0,
+                     after: 0,
+                     binary: true,
+                  },
+               ],
+            })
+         );
+      });
+
       it('single text file with changes', () => {
          const actual = getDiffParser(LogFormat.STAT)(
             diffSummarySingleFile(1, 2, 'package.json').stdOut


### PR DESCRIPTION
## What changed

- parse binary diff-stat entries that omit before/after byte counts
- retain the renamed path and mark the entry as binary with zero byte counts
- add regression coverage for a binary rename summary
- add a patch changeset

## Why

Git emits binary renames as `path | Bin`, without the `before -> after bytes` section. The existing parser only recognizes the sized form, leaving `DiffSummary.files` empty for renames.

Fixes #885.

## Checks

- `yarn workspace simple-git jest --runInBand test/unit/diff.spec.ts` (23 tests passed)
- `yarn tsc -p simple-git/tsconfig.release.json --noEmit`
- Biome check for all changed files
- `git diff --check`

Prepared with Codex assistance; the diff was reviewed and the checks above were run locally.
